### PR TITLE
chore(flake/nixpkgs): `59dff5cf` -> `e95998e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748064236,
-        "narHash": "sha256-o090mjLM6VcFSSmGpDEmbwbcdV9K8ExjjPoSW6J+fLE=",
+        "lastModified": 1748084678,
+        "narHash": "sha256-m/aMWBsB96YDLCu4t6WxTpsKzsxeK/Q5U9vjy0a6tz0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59dff5cf0a3f25e434505c8b248895701f26f6fc",
+        "rev": "e95998e65422d0967a27dcf89b5f61f3b87cf52b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`05649cdf`](https://github.com/NixOS/nixpkgs/commit/05649cdfa5cdeb072fbcf92f892a00665a6fefe3) | `` turbovnc: remove zlib reference ``                                                           |
| [`138393e0`](https://github.com/NixOS/nixpkgs/commit/138393e0bab1c6cd9a78aeba8dd196065cf1eefd) | `` ci/eval.combine: avoid parsing of plain text file into JSON ``                               |
| [`d87d760d`](https://github.com/NixOS/nixpkgs/commit/d87d760dfa6128c51e8248458029b08778726a69) | `` ci/eval.compare: use lib from pinned nixpkgs ``                                              |
| [`eccd9564`](https://github.com/NixOS/nixpkgs/commit/eccd9564abe5de9d9931f974dc0fe68887b73a96) | `` ci/eval: improve api when calling in steps ``                                                |
| [`82396d1f`](https://github.com/NixOS/nixpkgs/commit/82396d1f484e96c60c11809a0f5df3b7208be34e) | `` workflows/{codeowners,eval}: move env before run ``                                          |
| [`a22a61f6`](https://github.com/NixOS/nixpkgs/commit/a22a61f6bcc5320ee2ec59b988ed089758c8427b) | `` rstudio: fix .desktop file by properly escaping use of cmake variable ``                     |
| [`bb05bee4`](https://github.com/NixOS/nixpkgs/commit/bb05bee4e5f3a987bf83b537fdebb6c1198a7783) | `` nixosTests.mycelium: make less flaky ``                                                      |
| [`aee81dfd`](https://github.com/NixOS/nixpkgs/commit/aee81dfd3766cc923a3a9c378dd1e810c9360e88) | `` nix-search-tv: 2.1.6 -> 2.1.7 ``                                                             |
| [`ada0f1fb`](https://github.com/NixOS/nixpkgs/commit/ada0f1fb281ea239b10cc9a736616ef38977c701) | `` vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.99.2025041609 -> 1.100.2025051409 ``  |
| [`edc314c9`](https://github.com/NixOS/nixpkgs/commit/edc314c9c9aec817beda213029e6e8badbf1397a) | `` vscode-extensions.scalameta.metals: 1.50.0 -> 1.51.0 ``                                      |
| [`d948f92e`](https://github.com/NixOS/nixpkgs/commit/d948f92ed3106de124c1dd0566d7ee6b8e848ecf) | `` python3Packages.notobuilder: 0-unstable-2025-04-28 -> 0-unstable-2025-05-20 ``               |
| [`26bfe1ba`](https://github.com/NixOS/nixpkgs/commit/26bfe1bacce7af3171513adb148ab91d7c20575a) | `` uv: 0.7.7 -> 0.7.8 ``                                                                        |
| [`19acb808`](https://github.com/NixOS/nixpkgs/commit/19acb808050baf1ae26fc3f8f0ee2b263d45509e) | `` guix: add hpfr to meta.maintainers ``                                                        |
| [`5f72371b`](https://github.com/NixOS/nixpkgs/commit/5f72371b4d50fbb0a7e6b4074938e25861fa4417) | `` maintainers: add hpfr ``                                                                     |
| [`e67aaa32`](https://github.com/NixOS/nixpkgs/commit/e67aaa327a4dbeca5c0384c320400e12a887acb9) | `` parabolic: patch out bypassing wrapped executables ``                                        |
| [`f4ad89e4`](https://github.com/NixOS/nixpkgs/commit/f4ad89e41e840d43f75ccfb59d98772fde953eed) | `` guix: Fix guile-ssh detection ``                                                             |
| [`8892a5dc`](https://github.com/NixOS/nixpkgs/commit/8892a5dcb6b19b304f6d1aa1dc2b0b3fba3e5b78) | `` guix: Fix guile-ssh library load ``                                                          |
| [`d58570f1`](https://github.com/NixOS/nixpkgs/commit/d58570f1675011ba34b04d54d1935dd4221ca281) | `` mycelium: 0.6.0 -> 0.6.1 ``                                                                  |
| [`9f781f41`](https://github.com/NixOS/nixpkgs/commit/9f781f41dfb3f81ddfeb8db814910e8ca490ad84) | `` museum: copy web-templates to output ``                                                      |
| [`833514ae`](https://github.com/NixOS/nixpkgs/commit/833514ae8a0a25d1065981ce4b35c96e0a0e6857) | `` libretro.genesis-plus-gx: 0-unstable-2025-05-02 -> 0-unstable-2025-05-23 ``                  |
| [`559c4d01`](https://github.com/NixOS/nixpkgs/commit/559c4d01332b5fd739c28534d72d0be57bfdbf39) | `` nixos/gerrit: Pin Java version to 21 ``                                                      |
| [`680dda8c`](https://github.com/NixOS/nixpkgs/commit/680dda8cf1f6efce2affeb2aeeb3f9d089c90e48) | `` dust: add defelo as maintainer ``                                                            |
| [`813693e4`](https://github.com/NixOS/nixpkgs/commit/813693e40cb544e0678533e55cda2a0ce2f01560) | `` dust: enable tests ``                                                                        |
| [`039a9548`](https://github.com/NixOS/nixpkgs/commit/039a954892ac43ebe2d8b2f8b977122db710c969) | `` workflows/{check-shell,manual-nixos,manual-nixpkgs}: use get-mege-commit action ``           |
| [`48f6519c`](https://github.com/NixOS/nixpkgs/commit/48f6519ca3b6f06d4877639c8db7b33fb23b8469) | `` nakama: 3.26.0 -> 3.27.1 ``                                                                  |
| [`e48d9d61`](https://github.com/NixOS/nixpkgs/commit/e48d9d6174e77293235dd2f4e878f7214d0d8612) | `` workflows/get-merge-commit: move to composite action ``                                      |
| [`c77cfb92`](https://github.com/NixOS/nixpkgs/commit/c77cfb9239e1aad89f668e0599f076761d7771ad) | `` workflows: run on merge conflicts as well ``                                                 |
| [`277f7b99`](https://github.com/NixOS/nixpkgs/commit/277f7b998c4baa585360277203cb29f11b6e324b) | `` workflows/get-merge-commit: inline get-merge-commit.sh script as github-script ``            |
| [`e2137921`](https://github.com/NixOS/nixpkgs/commit/e21379218ce8549e73d46cce9a9ff8d0c82295d4) | `` README.md: fix NixOS logo ``                                                                 |
| [`e94e4255`](https://github.com/NixOS/nixpkgs/commit/e94e42557b1c256e09fa3e2617ff2e6fe0976567) | `` dust: add meta.changelog ``                                                                  |
| [`b8f6858e`](https://github.com/NixOS/nixpkgs/commit/b8f6858e45ea7b4ce568fa305918fd3f060b2625) | `` dust: add updateScript ``                                                                    |
| [`f10d01c4`](https://github.com/NixOS/nixpkgs/commit/f10d01c45a2df6662d460d36e82183a634becb67) | `` dust: add versionCheckHook ``                                                                |
| [`7c3ad7e0`](https://github.com/NixOS/nixpkgs/commit/7c3ad7e0414e52299657eed9866389f968996c07) | `` dust: use tag in fetchFromGitHub ``                                                          |
| [`f644ca5a`](https://github.com/NixOS/nixpkgs/commit/f644ca5a95e9ec6b04b165347a00631ea736eae2) | `` dust: use finalAttrs pattern ``                                                              |
| [`0b5d8ef5`](https://github.com/NixOS/nixpkgs/commit/0b5d8ef5a92126a03271e4ea5f6c95d678fa33f8) | `` gildas: 20250401_b -> 20250501_a ``                                                          |
| [`2566f9dc`](https://github.com/NixOS/nixpkgs/commit/2566f9dcb469b06241519a8185863d67773f943a) | `` workflows/backport: avoid retriggering workflows after adding "has: port to stable" label `` |
| [`d0a438a3`](https://github.com/NixOS/nixpkgs/commit/d0a438a3bdc2a2ab7129bb331516f6b8366ffbbc) | `` Make use of finalAttrs on some packages ``                                                   |
| [`46ef80c8`](https://github.com/NixOS/nixpkgs/commit/46ef80c87ae5b9dc6447e987826e13d641016bdd) | `` openlinkhub: 0.5.4 -> 0.5.6 ``                                                               |
| [`c57a2f65`](https://github.com/NixOS/nixpkgs/commit/c57a2f6509f527b486bdb5c5212769ffa5be6766) | `` cue: 0.12.1 -> 0.13.0 ``                                                                     |
| [`ef9840db`](https://github.com/NixOS/nixpkgs/commit/ef9840dbd2a539ec42eb9233fb436180b2ec314c) | `` python3Packages.ansible-core: 2.18.4 -> 2.18.6 ``                                            |
| [`2561a055`](https://github.com/NixOS/nixpkgs/commit/2561a055c7afd378588742e15e66c8001a6da1dd) | `` upnp-router-control: 0.3.4 -> 0.3.5 ``                                                       |
| [`5fa3d5d1`](https://github.com/NixOS/nixpkgs/commit/5fa3d5d187d187372e16cc3085e995c5330333cc) | `` btfs: 2.24 -> 3.1 ``                                                                         |
| [`95e1bc4b`](https://github.com/NixOS/nixpkgs/commit/95e1bc4b4d9848b8a862a847c80aa25f1134697d) | `` python312Packages.onnxruntime: 1.21.0 -> 1.22.0 ``                                           |
| [`e64244bc`](https://github.com/NixOS/nixpkgs/commit/e64244bc86663f708538183cc977f827e584fb9d) | `` dwlb: 0-unstable-2025-05-05 -> 0-unstable-2025-05-20 ``                                      |
| [`eead148a`](https://github.com/NixOS/nixpkgs/commit/eead148a3b84189591d70cf3447fc6a1bd65202b) | `` signal-desktop.ringrtc: use cubeb from nixpkgs ``                                            |
| [`a87981df`](https://github.com/NixOS/nixpkgs/commit/a87981df9aa3280e7b150ff16a8830ad0d7f7007) | `` cubeb: install pkg-config file ``                                                            |
| [`d33be52b`](https://github.com/NixOS/nixpkgs/commit/d33be52bb886488f23c8a6b5c3b81a8383b5bfce) | `` cubeb: make derivation customizable ``                                                       |
| [`8600e6b3`](https://github.com/NixOS/nixpkgs/commit/8600e6b358f42530a0fc0ef25e5a1b788d049d05) | `` cubeb: add myself to maintainers ``                                                          |
| [`43a98524`](https://github.com/NixOS/nixpkgs/commit/43a985240731a5244ac6283e3050f05a393195b4) | `` signal-desktop.webrtc: execute install hooks ``                                              |
| [`e7bc7a0e`](https://github.com/NixOS/nixpkgs/commit/e7bc7a0e4a3db07ba357deaf5583ee2b16c5263b) | `` signal-desktop.webrtc: patch in absolute lib paths for dynamic loader ``                     |
| [`a1699678`](https://github.com/NixOS/nixpkgs/commit/a169967875b3a307d961d5add49f8895a59372d1) | `` ISSUE_TEMPLATES: update releases following 25.11's branch-off ``                             |
| [`becdee5c`](https://github.com/NixOS/nixpkgs/commit/becdee5ccf892ea86f9d736da020a1bccfed155a) | `` python3Packages.ansible: 11.4.0 -> 11.5.0 ``                                                 |
| [`138fce2c`](https://github.com/NixOS/nixpkgs/commit/138fce2c617a9b1af84374468d1128d63db9d1c9) | `` python3Packages.google-auth-oauthlib: 1.2.1 -> 1.2.2 ``                                      |
| [`fba059e9`](https://github.com/NixOS/nixpkgs/commit/fba059e95683662f3301a7011d93ee2bf36b8447) | `` python3Packages.rdflib: 7.1.3 -> 7.1.4 ``                                                    |
| [`edf88097`](https://github.com/NixOS/nixpkgs/commit/edf880979370f74f949be2701469c62ee91871d9) | `` nixos/clash-verge: readd tunMode ``                                                          |
| [`8f91507e`](https://github.com/NixOS/nixpkgs/commit/8f91507efbb2ca319ac5f6e0b59465c4616c9738) | `` nixos/clash-verge: harden systemd service ``                                                 |
| [`cdc8c25c`](https://github.com/NixOS/nixpkgs/commit/cdc8c25cf46994ce0736a096a4cd27b3035a9f6c) | `` python3Packages.pymdown-extensions: 10.14.3 -> 10.15 ``                                      |
| [`f9ee8448`](https://github.com/NixOS/nixpkgs/commit/f9ee8448aabf0e8bedab768ddc0da568ad88d57f) | `` python3Packages.ase: 3.24.0 -> 3.25.0 ``                                                     |
| [`4d4805fc`](https://github.com/NixOS/nixpkgs/commit/4d4805fcee27e91db46706ac0ef920a71926e5f7) | `` python3Packages.aiomisc: 17.7.3 -> 17.7.7 ``                                                 |
| [`371e5493`](https://github.com/NixOS/nixpkgs/commit/371e54933a47446391b987ecb21ca7e4299039b5) | `` python3Packages.dash: 3.0.3 -> 3.0.4 ``                                                      |
| [`47a05695`](https://github.com/NixOS/nixpkgs/commit/47a0569504eb0b1898424de1c8c1b88337b13530) | `` wl-gammarelay-rs: 1.0.0 -> 1.0.1 ``                                                          |