### PR TITLE
chore(flake/nixpkgs): `e95998e6` -> `631b610a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748084678,
-        "narHash": "sha256-m/aMWBsB96YDLCu4t6WxTpsKzsxeK/Q5U9vjy0a6tz0=",
+        "lastModified": 1748089567,
+        "narHash": "sha256-Dvq/xr99ZZbAO5Oljjrq/QOIBHzUjNLYeFg2gzpALzA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e95998e65422d0967a27dcf89b5f61f3b87cf52b",
+        "rev": "631b610af879088bed8a804a26f81fbdbe679658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`631b610a`](https://github.com/NixOS/nixpkgs/commit/631b610af879088bed8a804a26f81fbdbe679658) | `` klipper: configurable extra Python packages ``                       |
| [`9a4eaf1b`](https://github.com/NixOS/nixpkgs/commit/9a4eaf1b615f74f197c97b06c81f6d5aba7a85e9) | `` qownnotes: 25.5.8 -> 25.5.10 ``                                      |
| [`856cb310`](https://github.com/NixOS/nixpkgs/commit/856cb3108ac6fbf9a833c23e745dd2af868f869d) | `` OWNERS: add myself to `lib/licenses.nix` ``                          |
| [`d65cae20`](https://github.com/NixOS/nixpkgs/commit/d65cae200824828127a05ebb4673f085b7985d63) | `` python3Packages.langgraph-checkpoint-postgres: Disable flaky test `` |
| [`2641210e`](https://github.com/NixOS/nixpkgs/commit/2641210e505b3d7960ea0eca46b19efa28b608cf) | `` cfn-nag: update gems ``                                              |
| [`b74ac7b2`](https://github.com/NixOS/nixpkgs/commit/b74ac7b252c76bb92fb39854d5de531c861eb6f8) | `` ugrep: 7.4.2 -> 7.4.3 ``                                             |
| [`a567bce5`](https://github.com/NixOS/nixpkgs/commit/a567bce53f3801cdc71427a192a1675c1c37f76f) | `` drawterm: 0-unstable-2025-03-18 -> 0-unstable-2025-05-18 ``          |
| [`d9416288`](https://github.com/NixOS/nixpkgs/commit/d9416288d088b825201dd21784ee2341cd909b30) | `` python3Packages.coiled: 1.95.0 -> 1.96.1 ``                          |
| [`5b13b7ea`](https://github.com/NixOS/nixpkgs/commit/5b13b7ea7ede2155eadd25cbadbb21857d300002) | `` got: 0.111 -> 0.112 ``                                               |
| [`64949a53`](https://github.com/NixOS/nixpkgs/commit/64949a53650be8f23c3aaba41c789e2c1cc8210c) | `` halo: 2.20.20 -> 2.20.21 ``                                          |
| [`44d582ea`](https://github.com/NixOS/nixpkgs/commit/44d582ea5c62406b8658d6599b57c2c648684bda) | `` pcmanfm: 1.3.2 -> 1.4.0 ``                                           |
| [`5903fd2a`](https://github.com/NixOS/nixpkgs/commit/5903fd2a6c4270d425e3a577bbaaf5905d828200) | `` padthv1: 0.9.23 -> 1.3.2 ``                                          |
| [`b0f8a1e4`](https://github.com/NixOS/nixpkgs/commit/b0f8a1e4874d79c6af7121e3b459abff4c482b80) | `` wavebox: 10.135.21-2 -> 10.136.15-2 ``                               |
| [`11e499f1`](https://github.com/NixOS/nixpkgs/commit/11e499f1d0597ea37ee8661830a8e347d1dea028) | `` poedit: 3.5.2 -> 3.6.2 ``                                            |