### PR TITLE
chore(flake/nixpkgs): `631b610a` -> `95b919fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748089567,
-        "narHash": "sha256-Dvq/xr99ZZbAO5Oljjrq/QOIBHzUjNLYeFg2gzpALzA=",
+        "lastModified": 1748093040,
+        "narHash": "sha256-q8QIOM4LpT+4OHvKr9ZHiKOhk9g0zra5RmMkqGGEiqA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "631b610af879088bed8a804a26f81fbdbe679658",
+        "rev": "95b919fd5ddf40aa966ba2be135d8feb9a32fc1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`61efce5d`](https://github.com/NixOS/nixpkgs/commit/61efce5d05dbd6a2e6b2757155bad9d0c017bc49) | `` sublime4-dev: 4196 -> 4199 ``                                                                     |
| [`ccb6f5e8`](https://github.com/NixOS/nixpkgs/commit/ccb6f5e88194a46593c96ae9f2c49a7b63cc7819) | `` sublime4: 4192 -> 4200 ``                                                                         |
| [`9f10bba3`](https://github.com/NixOS/nixpkgs/commit/9f10bba3908524e9fc98b0f3be4b25e91bfff78c) | `` maintainers: add p0lyw0lf ``                                                                      |
| [`d9e4682f`](https://github.com/NixOS/nixpkgs/commit/d9e4682fd40b988798c91bca24468d9f83230247) | `` zig: 0.14.0 -> 0.14.1 ``                                                                          |
| [`1e43d85c`](https://github.com/NixOS/nixpkgs/commit/1e43d85c3e09ce042269a035f2640ee475a70dd5) | `` python312Packages.tinygrad: skip failing test ``                                                  |
| [`a7158d09`](https://github.com/NixOS/nixpkgs/commit/a7158d09dcd706dd56e11811e1579e8233c31aea) | `` python312Packages.onnxmltools: cleanup, fix build ``                                              |
| [`c6fd5166`](https://github.com/NixOS/nixpkgs/commit/c6fd516649e2da02c4609815216519fa5ed0b4ac) | `` python312Packages.onnxruntime-tools: cleanup ``                                                   |
| [`a2e7a3c2`](https://github.com/NixOS/nixpkgs/commit/a2e7a3c2f99228f645e2bfe779b48a6dbe75531e) | `` python312Packages.onnx: 1.17.0 -> 1.18.0 ``                                                       |
| [`568b9ae4`](https://github.com/NixOS/nixpkgs/commit/568b9ae4f7199e9779a7156894bac96a6e0d55d6) | `` atlas: 0.33.0 -> 0.33.1 ``                                                                        |
| [`d21d8c27`](https://github.com/NixOS/nixpkgs/commit/d21d8c27d9aa768e8815d995091b63eafd8d289a) | `` grafana: 12.0.0 -> 12.0.0+security-01 ``                                                          |
| [`547dc473`](https://github.com/NixOS/nixpkgs/commit/547dc4736e76a4d4d8b5a86fd59f5cfbddd4c982) | `` nltk-data: add all downloadables ``                                                               |
| [`f2f2eab1`](https://github.com/NixOS/nixpkgs/commit/f2f2eab113a032d841cd72b4ed637c2d34f7f73d) | `` treewide: nltk-data.snowball_data -> nltk-data.snowball-data ``                                   |
| [`a4c3b3ef`](https://github.com/NixOS/nixpkgs/commit/a4c3b3eff292a2381ad365168ea635d70ed343c2) | `` treewide: nltk-data.averaged_perceptron_tagger_eng -> nltk-data.averaged-perceptron-tagger-eng `` |
| [`00bd6716`](https://github.com/NixOS/nixpkgs/commit/00bd671646bf414967b7b2a25e2852a56b3c74a3) | `` treewide: nltk-data.averaged_perceptron_tagger -> nltk-data.averaged-perceptron-tagger ``         |
| [`198faa88`](https://github.com/NixOS/nixpkgs/commit/198faa882b91b7ecaa8b753440eb4937d81e10a6) | `` treewide: nltk-data.punkt_tab -> nltk-data.punkt-tab ``                                           |
| [`ac0ddf0c`](https://github.com/NixOS/nixpkgs/commit/ac0ddf0cb243694b0f90e61c5a4df85ea3226da6) | `` nltk-data: fix searchability ``                                                                   |
| [`86575951`](https://github.com/NixOS/nixpkgs/commit/86575951b6eb7fd1345e0f629482197ec335e8f2) | `` nltk-data: skip fixupPhase to avoid needless patching attempts ``                                 |
| [`293e1947`](https://github.com/NixOS/nixpkgs/commit/293e194753f0da12e73a1938cea0dfdb7196d390) | `` nltk-data: add bengsparks to maintainers ``                                                       |
| [`bc245237`](https://github.com/NixOS/nixpkgs/commit/bc2452370dc9c73372a2a1dc6d070cbf978c0b29) | `` mask: add defelo as maintainer ``                                                                 |
| [`39a061a5`](https://github.com/NixOS/nixpkgs/commit/39a061a59785232b2a7b48b5c1612370afffd680) | `` mask: enable tests ``                                                                             |
| [`b28032e3`](https://github.com/NixOS/nixpkgs/commit/b28032e3b2c75d5cf998c25d77e5677210c5fdef) | `` mask: add updateScript ``                                                                         |
| [`a41ff318`](https://github.com/NixOS/nixpkgs/commit/a41ff318e16f6f4a777e79be3ea4061ed7b8824c) | `` mask: add versionCheckHook ``                                                                     |
| [`c33d4c38`](https://github.com/NixOS/nixpkgs/commit/c33d4c38078efcb8a5b6dc13b07d4c6016b9a33f) | `` mask: remove `with lib;` ``                                                                       |
| [`d8937c1e`](https://github.com/NixOS/nixpkgs/commit/d8937c1e01550c9c69e84284411680a29ccb9da6) | `` mask: use tag in fetchFromGitHub ``                                                               |
| [`8a39c749`](https://github.com/NixOS/nixpkgs/commit/8a39c749167c58f732e46fc29fe34cc66d4ef612) | `` mask: use finalAttrs pattern ``                                                                   |
| [`d8f60300`](https://github.com/NixOS/nixpkgs/commit/d8f60300b82ecae3a8976822c21bb0fbbb536851) | `` ndstrim: remove workaround ``                                                                     |
| [`fdfddf75`](https://github.com/NixOS/nixpkgs/commit/fdfddf7503e9f9d200271cbebc07506e9531027b) | `` legcord: 1.1.3 -> 1.1.4 ``                                                                        |
| [`7de73b50`](https://github.com/NixOS/nixpkgs/commit/7de73b508b28057b89240bd9c4b78170726ac69e) | `` sleek: don't vendor Cargo.lock ``                                                                 |
| [`e351e1cd`](https://github.com/NixOS/nixpkgs/commit/e351e1cdfb2b2cd4a6499828849d4340d10f3b2f) | `` lsp-plugins: 1.2.21 -> 1.2.22 ``                                                                  |
| [`95e07f4b`](https://github.com/NixOS/nixpkgs/commit/95e07f4bd3a4b7f015b0bdecf9778b63649d5c18) | `` gz-cmake: enable tests again ``                                                                   |
| [`b448c6cf`](https://github.com/NixOS/nixpkgs/commit/b448c6cf164cce096db2a5a9c5ce1f50c1d5fafe) | `` veroroute: init at 2.39 ``                                                                        |