### PR TITLE
chore(flake/nixpkgs): `95b919fd` -> `2f22dc97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748093040,
-        "narHash": "sha256-q8QIOM4LpT+4OHvKr9ZHiKOhk9g0zra5RmMkqGGEiqA=",
+        "lastModified": 1748095444,
+        "narHash": "sha256-CYIIjOJBxXKJRSE+TAzregr+gocDf3dh5iFX95S9Kvc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95b919fd5ddf40aa966ba2be135d8feb9a32fc1e",
+        "rev": "2f22dc972ea982861fabc60dba4ab474d17440f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`f13f2576`](https://github.com/NixOS/nixpkgs/commit/f13f2576def3fb6d376a467f29b75d6285cf323a) | `` protolint: remove me as maintainer ``                            |
| [`8d5b47e9`](https://github.com/NixOS/nixpkgs/commit/8d5b47e9b88fcee77431773f52b36f6c6e8f1f41) | `` cue: use finalAttrs ``                                           |
| [`c6fe53c5`](https://github.com/NixOS/nixpkgs/commit/c6fe53c58e34e33c164ab54f3b9dec3c56996ee9) | `` nixos-rebuild-ng: handle subflakes correctly ``                  |
| [`e0d3828e`](https://github.com/NixOS/nixpkgs/commit/e0d3828e91f752b6084876861f621ba22f7c7a1c) | `` mdfried: init at 0.12.1 ``                                       |
| [`c5d1ccd4`](https://github.com/NixOS/nixpkgs/commit/c5d1ccd473148df373b253a9deb32fd1a8ff5344) | `` atuin: fix systemd after/wants targets ``                        |
| [`4a1b7155`](https://github.com/NixOS/nixpkgs/commit/4a1b7155e8f3cfe4454430a3ed83d0eb773c828e) | `` lnd: 0.18.5 -> 0.19.0 ``                                         |
| [`1ef83944`](https://github.com/NixOS/nixpkgs/commit/1ef83944095e8fbafbee45585e64bf6b0f0b39db) | `` kohighlights: remove double wrapping, use pyproject = false ``   |
| [`bb23492d`](https://github.com/NixOS/nixpkgs/commit/bb23492d23460e00c4aff751d51ba04d2397da36) | `` doc/rl2505: move variants to 25.05 ``                            |
| [`6c20afc2`](https://github.com/NixOS/nixpkgs/commit/6c20afc2637f040df1b525321f52541bb8584b50) | `` maintainers: add benjajaja ``                                    |
| [`22f2e258`](https://github.com/NixOS/nixpkgs/commit/22f2e258af4786c8504c9b20f7047757dfc9a0ea) | `` nixos/security: add landlock, yama, and bpf defaults ``          |
| [`a3834693`](https://github.com/NixOS/nixpkgs/commit/a38346938f744cc9aaf099da0389fbbd7431453d) | `` jetbrains.plugins.test: Also test bin/src packages explicitly `` |
| [`3f8895ac`](https://github.com/NixOS/nixpkgs/commit/3f8895ac373c81b3ed5fea49756bc25ae684791a) | `` bulloak: 0.8.0 -> 0.8.1 ``                                       |
| [`72c84cbe`](https://github.com/NixOS/nixpkgs/commit/72c84cbebbd30294a22d88526d247268216c4867) | `` jetbrains: fix format ``                                         |
| [`b9b40bcd`](https://github.com/NixOS/nixpkgs/commit/b9b40bcd13cecba78eaa41f742376b887ad5b4eb) | `` jetbrains: remove obsolete file ``                               |
| [`ac791605`](https://github.com/NixOS/nixpkgs/commit/ac79160520d75ac21e84eff4ab77630632cd6fae) | `` jetbrains: move test to package ``                               |
| [`6b1e8c30`](https://github.com/NixOS/nixpkgs/commit/6b1e8c30c84288764ad81af959f30963733fe816) | `` jetbrains: fix format in README ``                               |
| [`4b75b7a4`](https://github.com/NixOS/nixpkgs/commit/4b75b7a46eecb697c2fe027e2a46a7ba9efa0ec3) | `` jetbrains: add and improve tests ``                              |