### PR TITLE
chore(flake/nixpkgs): `2f22dc97` -> `90d72a1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748095444,
-        "narHash": "sha256-CYIIjOJBxXKJRSE+TAzregr+gocDf3dh5iFX95S9Kvc=",
+        "lastModified": 1748099098,
+        "narHash": "sha256-ljVrFUsBUOjitAVAU2VPVDfEmkseP7qhmcR717qxyN4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2f22dc972ea982861fabc60dba4ab474d17440f8",
+        "rev": "90d72a1d8c08676f5e9f80b20cedb43b23f5a636",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a91fbe12`](https://github.com/NixOS/nixpkgs/commit/a91fbe120df3d35cb16d3de469a7421faf274ca8) | `` unzoo: drop ``                                                       |
| [`dd612da3`](https://github.com/NixOS/nixpkgs/commit/dd612da33a2ab4c81a8c2fb0e05b080b23e142bf) | `` libretro.gambatte: 0-unstable-2025-05-02 -> 0-unstable-2025-05-16 `` |
| [`13be7c05`](https://github.com/NixOS/nixpkgs/commit/13be7c056b7e2a0b6d8ef4a01ed1187538d95cce) | `` quaternion-qt5: remove ``                                            |
| [`78481e65`](https://github.com/NixOS/nixpkgs/commit/78481e65b74b71588ac1a3b0254c61f74530a09e) | `` iosevka-bin: 33.2.2 -> 33.2.3 ``                                     |
| [`31bd988f`](https://github.com/NixOS/nixpkgs/commit/31bd988fd44e9798b01f63904f873942cae08f29) | `` brush: 0.2.17 -> 0.2.18 ``                                           |
| [`7a7dad34`](https://github.com/NixOS/nixpkgs/commit/7a7dad344b2aa54c648b493707d6844e11f61cc7) | `` typst: set version explicitly ``                                     |
| [`5d599101`](https://github.com/NixOS/nixpkgs/commit/5d599101f53e88579a9fe35355b4f13b1015acbc) | `` mergiraf: 0.8.0 -> 0.8.1 ``                                          |
| [`0ea94c8c`](https://github.com/NixOS/nixpkgs/commit/0ea94c8c02b5a5da6728fbc4b544005e6a779995) | `` home-manager: 0-unstable-2025-05-13 -> 0-unstable-2025-05-23 ``      |
| [`e4ee2c14`](https://github.com/NixOS/nixpkgs/commit/e4ee2c14f04d6248844fd5fa157400390b60270e) | `` discord: 0.0.94 -> 0.0.95 ``                                         |
| [`38162484`](https://github.com/NixOS/nixpkgs/commit/381624849761a493851d28cbd72f208c82be5efb) | `` python3Packages.coredis: refactor ``                                 |
| [`5aa2d438`](https://github.com/NixOS/nixpkgs/commit/5aa2d4383e50dd633fe0fcd1376092bd7e7a3e0a) | `` python3Packages.coredis: switch to pypa builder ``                   |
| [`f6f1ae32`](https://github.com/NixOS/nixpkgs/commit/f6f1ae3261354289b247f0a768fd8e136d9f33c0) | `` python3Packages.coredis: 4.20.0 -> 4.22.0 ``                         |
| [`655ae94e`](https://github.com/NixOS/nixpkgs/commit/655ae94ea51ec0194c79bbae4c3c24bcb9de1a58) | `` libcpuid: 0.7.1 -> 0.8.0 ``                                          |