### PR TITLE
chore(flake/nixpkgs): `90d72a1d` -> `c26cfcca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748099098,
-        "narHash": "sha256-ljVrFUsBUOjitAVAU2VPVDfEmkseP7qhmcR717qxyN4=",
+        "lastModified": 1748103343,
+        "narHash": "sha256-rTf4NvzT+P7owzUD9CxFpWp8bteNFUt6l5boszD16w4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "90d72a1d8c08676f5e9f80b20cedb43b23f5a636",
+        "rev": "c26cfcca93adcd5ec6fd2ef97a0611512d7bc8cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`3277dd22`](https://github.com/NixOS/nixpkgs/commit/3277dd227d0298a06702b684c0937c0100a2ef9a) | `` gitlab-container-registry: fix build on darwin with sandbox ``           |
| [`963babe8`](https://github.com/NixOS/nixpkgs/commit/963babe8514638c8e97b1f304d434d377caef7ce) | `` nvme-rs: init at 0.1.0 ``                                                |
| [`2e2e96f1`](https://github.com/NixOS/nixpkgs/commit/2e2e96f1f568efb21cef66818ecc6ac1953b5a27) | `` kak-tree-sitter-unwrapped: 1.1.3 -> 2.0.0 ``                             |
| [`7f298b2a`](https://github.com/NixOS/nixpkgs/commit/7f298b2a65644b3dde8d92b2b5d444aa61e76b09) | `` fastfetch: 2.43.0 -> 2.44.0 ``                                           |
| [`5a621f79`](https://github.com/NixOS/nixpkgs/commit/5a621f79f32072cf6f39631ca407ed3635031900) | `` home-assistant-custom-components.versatile_thermostat: 7.3.0 -> 7.3.1 `` |
| [`69ec89cd`](https://github.com/NixOS/nixpkgs/commit/69ec89cd7a7a264fd55c6f1e8321d14ade9171df) | `` zoom-us: 6.4.6.* -> 6.4.10.* ``                                          |
| [`0a666d53`](https://github.com/NixOS/nixpkgs/commit/0a666d5335277764c8290726edbc2f7b3e8b78e6) | `` substituteAll{,Files}: drop ``                                           |
| [`e6b41898`](https://github.com/NixOS/nixpkgs/commit/e6b41898b6982be3c05aae0d713907cef1e5e993) | `` vimPlugins.colorful-winsep-nvim: init at 2025-04-11 ``                   |
| [`ffd3d068`](https://github.com/NixOS/nixpkgs/commit/ffd3d068e7e8b142c7cfce94cc9985a6e733778a) | `` vimPlugins.contextfiles-nvim: init at 2025-05-07 ``                      |
| [`c00514cf`](https://github.com/NixOS/nixpkgs/commit/c00514cf877bf84a6f7aa6cfad12ae484c563c14) | `` zziplib: 0.13.78 -> 0.13.79 ``                                           |