### PR TITLE
chore(flake/patched-nixpkgs): `40f15db8` -> `76121e3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "patched-nixpkgs": {
       "locked": {
-        "lastModified": 1746961062,
-        "narHash": "sha256-7krN5Ii+jFQTIQL/KDQgjU7qRpbs9Ndgd0POccM+nb0=",
+        "lastModified": 1748133736,
+        "narHash": "sha256-8DCZF+SHXa7P9O9op2ET7qJtPomzQ49jy2vjzrHocg4=",
         "owner": "TomaSajt",
         "repo": "nixpkgs",
-        "rev": "40f15db812bdec49cd4e64ba46fc355b7e2af358",
+        "rev": "76121e3e5db9bfcc4b604b4093abea7b1aa3109e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                                                         |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`76121e3e`](https://github.com/TomaSajt/nixpkgs/commit/76121e3e5db9bfcc4b604b4093abea7b1aa3109e) | `` WIP ``                                                                                                       |
| [`2ef41329`](https://github.com/TomaSajt/nixpkgs/commit/2ef413296a5616033a3e8ed11c9527f16dee7a57) | `` zed-editor: remove patch for duplicated cargo deps ``                                                        |
| [`f23e8dc3`](https://github.com/TomaSajt/nixpkgs/commit/f23e8dc34a74716218375b7a77d55ed670cb32d3) | `` air-formatter: remove patch for duplicated cargo deps ``                                                     |
| [`ddc2a15e`](https://github.com/TomaSajt/nixpkgs/commit/ddc2a15e5629e968b475734d2a804f18cbc84c75) | `` oxide-rs: remove patch for duplicated cargo deps ``                                                          |
| [`b32302b2`](https://github.com/TomaSajt/nixpkgs/commit/b32302b2a5d5de8f2366cb807178ef2564d2eb44) | `` matrix-appservice-slack: remove patch for duplicated cargo deps ``                                           |
| [`726c6c33`](https://github.com/TomaSajt/nixpkgs/commit/726c6c33a8252fec67420e7ab03123703d838b2c) | `` rquickshare: remove patch for duplicated cargo deps ``                                                       |
| [`651c9c58`](https://github.com/TomaSajt/nixpkgs/commit/651c9c5804d076dfb32b85589211e6ef76ad0046) | `` treewide: fix search location of crates inside cargoDepsCopy ``                                              |
| [`5127a2de`](https://github.com/TomaSajt/nixpkgs/commit/5127a2de227a02f675d1bfb563db051fa819c522) | `` rustPlatform.fetchCargoVendor: allow duplicated dependencies ``                                              |
| [`a22a61f6`](https://github.com/TomaSajt/nixpkgs/commit/a22a61f6bcc5320ee2ec59b988ed089758c8427b) | `` rstudio: fix .desktop file by properly escaping use of cmake variable ``                                     |
| [`bb05bee4`](https://github.com/TomaSajt/nixpkgs/commit/bb05bee4e5f3a987bf83b537fdebb6c1198a7783) | `` nixosTests.mycelium: make less flaky ``                                                                      |
| [`aee81dfd`](https://github.com/TomaSajt/nixpkgs/commit/aee81dfd3766cc923a3a9c378dd1e810c9360e88) | `` nix-search-tv: 2.1.6 -> 2.1.7 ``                                                                             |
| [`ada0f1fb`](https://github.com/TomaSajt/nixpkgs/commit/ada0f1fb281ea239b10cc9a736616ef38977c701) | `` vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.99.2025041609 -> 1.100.2025051409 ``                  |
| [`edc314c9`](https://github.com/TomaSajt/nixpkgs/commit/edc314c9c9aec817beda213029e6e8badbf1397a) | `` vscode-extensions.scalameta.metals: 1.50.0 -> 1.51.0 ``                                                      |
| [`59dff5cf`](https://github.com/TomaSajt/nixpkgs/commit/59dff5cf0a3f25e434505c8b248895701f26f6fc) | `` terminator: 2.1.4 -> 2.1.5 ``                                                                                |
| [`d948f92e`](https://github.com/TomaSajt/nixpkgs/commit/d948f92ed3106de124c1dd0566d7ee6b8e848ecf) | `` python3Packages.notobuilder: 0-unstable-2025-04-28 -> 0-unstable-2025-05-20 ``                               |
| [`26bfe1ba`](https://github.com/TomaSajt/nixpkgs/commit/26bfe1bacce7af3171513adb148ab91d7c20575a) | `` uv: 0.7.7 -> 0.7.8 ``                                                                                        |
| [`19acb808`](https://github.com/TomaSajt/nixpkgs/commit/19acb808050baf1ae26fc3f8f0ee2b263d45509e) | `` guix: add hpfr to meta.maintainers ``                                                                        |
| [`5f72371b`](https://github.com/TomaSajt/nixpkgs/commit/5f72371b4d50fbb0a7e6b4074938e25861fa4417) | `` maintainers: add hpfr ``                                                                                     |
| [`f4ad89e4`](https://github.com/TomaSajt/nixpkgs/commit/f4ad89e41e840d43f75ccfb59d98772fde953eed) | `` guix: Fix guile-ssh detection ``                                                                             |
| [`8892a5dc`](https://github.com/TomaSajt/nixpkgs/commit/8892a5dcb6b19b304f6d1aa1dc2b0b3fba3e5b78) | `` guix: Fix guile-ssh library load ``                                                                          |
| [`d80991f4`](https://github.com/TomaSajt/nixpkgs/commit/d80991f44ce8e743324f243573a5df643ed73674) | `` jetbrains-jdk: 21.0.4 -> 21.0.6 ``                                                                           |
| [`d58570f1`](https://github.com/TomaSajt/nixpkgs/commit/d58570f1675011ba34b04d54d1935dd4221ca281) | `` mycelium: 0.6.0 -> 0.6.1 ``                                                                                  |
| [`15c77275`](https://github.com/TomaSajt/nixpkgs/commit/15c772758920995779ffc6f2a60c0ab11452b9b3) | `` python3Packages.docling-serve: 0.10.1 -> 0.11.0 ``                                                           |
| [`9f781f41`](https://github.com/TomaSajt/nixpkgs/commit/9f781f41dfb3f81ddfeb8db814910e8ca490ad84) | `` museum: copy web-templates to output ``                                                                      |
| [`833514ae`](https://github.com/TomaSajt/nixpkgs/commit/833514ae8a0a25d1065981ce4b35c96e0a0e6857) | `` libretro.genesis-plus-gx: 0-unstable-2025-05-02 -> 0-unstable-2025-05-23 ``                                  |
| [`559c4d01`](https://github.com/TomaSajt/nixpkgs/commit/559c4d01332b5fd739c28534d72d0be57bfdbf39) | `` nixos/gerrit: Pin Java version to 21 ``                                                                      |
| [`680dda8c`](https://github.com/TomaSajt/nixpkgs/commit/680dda8cf1f6efce2affeb2aeeb3f9d089c90e48) | `` dust: add defelo as maintainer ``                                                                            |
| [`813693e4`](https://github.com/TomaSajt/nixpkgs/commit/813693e40cb544e0678533e55cda2a0ce2f01560) | `` dust: enable tests ``                                                                                        |
| [`ab64676e`](https://github.com/TomaSajt/nixpkgs/commit/ab64676e8139e6a5a4570b3b83478a5184fd38df) | `` harper: 0.36.0 -> 0.38.0 ``                                                                                  |
| [`854046f0`](https://github.com/TomaSajt/nixpkgs/commit/854046f01764c9d114c8ab178d1487dfb08b38f8) | `` luminance-hdr: Fix build with current boost ``                                                               |
| [`15f34784`](https://github.com/TomaSajt/nixpkgs/commit/15f3478472311eb028d8d6039875c35318a69156) | `` scip-go: 0.1.23 -> 0.1.24 ``                                                                                 |
| [`039a9548`](https://github.com/TomaSajt/nixpkgs/commit/039a954892ac43ebe2d8b2f8b977122db710c969) | `` workflows/{check-shell,manual-nixos,manual-nixpkgs}: use get-mege-commit action ``                           |
| [`48f6519c`](https://github.com/TomaSajt/nixpkgs/commit/48f6519ca3b6f06d4877639c8db7b33fb23b8469) | `` nakama: 3.26.0 -> 3.27.1 ``                                                                                  |
| [`b0f6bd05`](https://github.com/TomaSajt/nixpkgs/commit/b0f6bd05f44e90fb7ca7ad749d4c72b1f1e12c75) | `` gdevelop: 5.5.229 -> 5.5.231 ``                                                                              |
| [`b4b2d723`](https://github.com/TomaSajt/nixpkgs/commit/b4b2d7230a1055241df9a3ff6358bc684442004d) | `` gdevelop: added update script ``                                                                             |
| [`e48d9d61`](https://github.com/TomaSajt/nixpkgs/commit/e48d9d6174e77293235dd2f4e878f7214d0d8612) | `` workflows/get-merge-commit: move to composite action ``                                                      |
| [`c77cfb92`](https://github.com/TomaSajt/nixpkgs/commit/c77cfb9239e1aad89f668e0599f076761d7771ad) | `` workflows: run on merge conflicts as well ``                                                                 |
| [`277f7b99`](https://github.com/TomaSajt/nixpkgs/commit/277f7b998c4baa585360277203cb29f11b6e324b) | `` workflows/get-merge-commit: inline get-merge-commit.sh script as github-script ``                            |
| [`5cd7c7ed`](https://github.com/TomaSajt/nixpkgs/commit/5cd7c7edf045b6a11f76c34fea34aa076120d84d) | `` trivy: 0.61.1 -> 0.62.1 ``                                                                                   |
| [`e2137921`](https://github.com/TomaSajt/nixpkgs/commit/e21379218ce8549e73d46cce9a9ff8d0c82295d4) | `` README.md: fix NixOS logo ``                                                                                 |
| [`0a5609ac`](https://github.com/TomaSajt/nixpkgs/commit/0a5609ac1d56f648cdad4ba6feceddd9700a5e0d) | `` distroshelf: 1.0.6 -> 1.0.7 ``                                                                               |
| [`dc293fac`](https://github.com/TomaSajt/nixpkgs/commit/dc293fac276a5a3e8227302f2e5bb26295deaace) | `` deepsource: 0.8.6 -> 0.9.0 ``                                                                                |
| [`d8b45fea`](https://github.com/TomaSajt/nixpkgs/commit/d8b45fea9bd6b2ac6645eca419d87c659b8101de) | `` examine: init at 1.0.0 ``                                                                                    |
| [`56cc6915`](https://github.com/TomaSajt/nixpkgs/commit/56cc6915b76bfd4afbd2742f4666d7f86591a1dc) | `` consul: 1.21.0 -> 1.21.1 ``                                                                                  |
| [`5b56d596`](https://github.com/TomaSajt/nixpkgs/commit/5b56d5967baec35aab0687a66157e521338bdb39) | `` python313Packages.sensorpro-ble: 0.7.0 -> 0.7.1 ``                                                           |
| [`d8a3ff92`](https://github.com/TomaSajt/nixpkgs/commit/d8a3ff920361c59259027bbb1c34829b506d232d) | `` python313Packages.python-gvm: 26.1.1 -> 26.2.0 ``                                                            |
| [`50c9fe74`](https://github.com/TomaSajt/nixpkgs/commit/50c9fe7400e04c388a0dc4d519d9682e24fd135d) | `` grype: 0.92.0 -> 0.92.2 ``                                                                                   |
| [`094f9b71`](https://github.com/TomaSajt/nixpkgs/commit/094f9b71d05c7ab0d56aa5609c403c2bff0bd7dd) | `` jetbrains-toolbox: 2.6.1.40902 -> 2.6.2.41321 ``                                                             |
| [`48ea9fc8`](https://github.com/TomaSajt/nixpkgs/commit/48ea9fc860772e2cf9258e849f6f102a8279931f) | `` python313Packages.inkbird-ble: 0.16.1 -> 0.16.2 ``                                                           |
| [`93149262`](https://github.com/TomaSajt/nixpkgs/commit/931492623932d2b67a4c532793b7871c718d8526) | `` jetbrains.plugins: add go-template, cucumber-for-java, gherkin, maven-helper and update existing plugins. `` |
| [`79d9be98`](https://github.com/TomaSajt/nixpkgs/commit/79d9be9810314eca39cd4062191fb331058c291c) | `` cfripper: 1.17.1 -> 1.17.2 ``                                                                                |
| [`fa1afba2`](https://github.com/TomaSajt/nixpkgs/commit/fa1afba267fb070d7858490ebdea72ddbd41c04c) | `` goa: 3.21.0 -> 3.21.1 ``                                                                                     |
| [`692a12b6`](https://github.com/TomaSajt/nixpkgs/commit/692a12b6c40972dfe1f7a01abb4099e11775cf82) | `` gpg-tui: 0.11.0 -> 0.11.1 ``                                                                                 |
| [`049f6263`](https://github.com/TomaSajt/nixpkgs/commit/049f62637b4a4f662e282c17390f32e4681aa0a5) | `` quick-webapps: init at 1.0.2 ``                                                                              |
| [`e3454e65`](https://github.com/TomaSajt/nixpkgs/commit/e3454e65e1663655daa1292399464a600c629f19) | `` dotslash: 0.5.2 -> 0.5.3 ``                                                                                  |
| [`87170c74`](https://github.com/TomaSajt/nixpkgs/commit/87170c742193d0b15ea4b678a6fed61af381503f) | `` doc/rl-2505: fix renovate release notes link ``                                                              |
| [`67e8b7b0`](https://github.com/TomaSajt/nixpkgs/commit/67e8b7b03f02daebb58febbf56a82ce05a0042f1) | `` kddockwidgets: 2.2.4 -> 2.2.5 ``                                                                             |