### PR TITLE
chore(flake/nixpkgs): `fe51d348` -> `edb3633f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "lastModified": 1748123162,
+        "narHash": "sha256-1fROmP+xlRkSiZ2bTH9JM6b4NUREhCerESEKQBKBkEw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "edb3633f9100d9277d1c9af245a4e9337a980c07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`20932506`](https://github.com/NixOS/nixpkgs/commit/209325068056921282bc77b6315726438d013fa5) | `` phpunit: 12.1.5 -> 12.1.6 ``                                                                |
| [`93ab2d88`](https://github.com/NixOS/nixpkgs/commit/93ab2d8822936a8ee14af24b8c36e145e1cf78be) | `` ladybird: 0-unstable-2025-05-18 -> 0-unstable-2025-05-24 ``                                 |
| [`86dd94e4`](https://github.com/NixOS/nixpkgs/commit/86dd94e458168ef467d4c0aee06df90ef649951a) | `` python3Packages.pyais: 2.9.2 -> 2.9.4 ``                                                    |
| [`cb3f7bdb`](https://github.com/NixOS/nixpkgs/commit/cb3f7bdbf8c0d9ed3a79bb2cbbab2b6553be534b) | `` python3Packages.django-stubs-ext: 5.1.3 -> 5.2.0 ``                                         |
| [`27e13d37`](https://github.com/NixOS/nixpkgs/commit/27e13d37f5b5b1b55dc6b1d7f5e17dae1f7f7158) | `` python3Packages.dj-database-url: 2.3.0 -> 3.0.0 ``                                          |
| [`a3564f44`](https://github.com/NixOS/nixpkgs/commit/a3564f44239a3941574f32048efacd5cef1a3545) | `` python3Packages.asn1: 3.0.1 -> 3.1.0 ``                                                     |
| [`fd7cdab6`](https://github.com/NixOS/nixpkgs/commit/fd7cdab61f9f4e793379d57922e5956c360ed082) | `` nixos/tests/lasuite-docs: init ``                                                           |
| [`f3120f07`](https://github.com/NixOS/nixpkgs/commit/f3120f071074397fe4b45414c2733f756887d027) | `` nixos/lasuite-docs: init ``                                                                 |
| [`a2d01ca3`](https://github.com/NixOS/nixpkgs/commit/a2d01ca3d18cb5ce7e51ea6c1afd94ebd3db5e1e) | `` linuxPackages.prl-tools: 20.3.0-55895 -> 20.3.1-55959 ``                                    |
| [`90b83812`](https://github.com/NixOS/nixpkgs/commit/90b83812360e84a3f284666a8eebfe9bcfe99437) | `` libretro.dosbox-pure: 0-unstable-2025-05-09 -> 0-unstable-2025-05-24 ``                     |
| [`3277dd22`](https://github.com/NixOS/nixpkgs/commit/3277dd227d0298a06702b684c0937c0100a2ef9a) | `` gitlab-container-registry: fix build on darwin with sandbox ``                              |
| [`1ccff76a`](https://github.com/NixOS/nixpkgs/commit/1ccff76a47de1739518fcb4ea7939783298d1b08) | `` eww: 0.6.0-unstable-2025-05-13 -> 0.6.0-unstable-2025-05-18 ``                              |
| [`b924dfeb`](https://github.com/NixOS/nixpkgs/commit/b924dfebeb1d6072172777e8e19f62463fe3a28e) | `` python3Packages.roadrecon: 1.6.1 -> 1.6.2 ``                                                |
| [`a91fbe12`](https://github.com/NixOS/nixpkgs/commit/a91fbe120df3d35cb16d3de469a7421faf274ca8) | `` unzoo: drop ``                                                                              |
| [`dd612da3`](https://github.com/NixOS/nixpkgs/commit/dd612da33a2ab4c81a8c2fb0e05b080b23e142bf) | `` libretro.gambatte: 0-unstable-2025-05-02 -> 0-unstable-2025-05-16 ``                        |
| [`13be7c05`](https://github.com/NixOS/nixpkgs/commit/13be7c056b7e2a0b6d8ef4a01ed1187538d95cce) | `` quaternion-qt5: remove ``                                                                   |
| [`963babe8`](https://github.com/NixOS/nixpkgs/commit/963babe8514638c8e97b1f304d434d377caef7ce) | `` nvme-rs: init at 0.1.0 ``                                                                   |
| [`f13f2576`](https://github.com/NixOS/nixpkgs/commit/f13f2576def3fb6d376a467f29b75d6285cf323a) | `` protolint: remove me as maintainer ``                                                       |
| [`8d5b47e9`](https://github.com/NixOS/nixpkgs/commit/8d5b47e9b88fcee77431773f52b36f6c6e8f1f41) | `` cue: use finalAttrs ``                                                                      |
| [`61efce5d`](https://github.com/NixOS/nixpkgs/commit/61efce5d05dbd6a2e6b2757155bad9d0c017bc49) | `` sublime4-dev: 4196 -> 4199 ``                                                               |
| [`ccb6f5e8`](https://github.com/NixOS/nixpkgs/commit/ccb6f5e88194a46593c96ae9f2c49a7b63cc7819) | `` sublime4: 4192 -> 4200 ``                                                                   |
| [`9f10bba3`](https://github.com/NixOS/nixpkgs/commit/9f10bba3908524e9fc98b0f3be4b25e91bfff78c) | `` maintainers: add p0lyw0lf ``                                                                |
| [`c6fe53c5`](https://github.com/NixOS/nixpkgs/commit/c6fe53c58e34e33c164ab54f3b9dec3c56996ee9) | `` nixos-rebuild-ng: handle subflakes correctly ``                                             |
| [`631b610a`](https://github.com/NixOS/nixpkgs/commit/631b610af879088bed8a804a26f81fbdbe679658) | `` klipper: configurable extra Python packages ``                                              |
| [`528d8b16`](https://github.com/NixOS/nixpkgs/commit/528d8b163308fca52239cadf919cf6449d741aeb) | `` python313Packages.tencentcloud-sdk-python: 3.0.1385 -> 3.0.1386 ``                          |
| [`9a4eaf1b`](https://github.com/NixOS/nixpkgs/commit/9a4eaf1b615f74f197c97b06c81f6d5aba7a85e9) | `` qownnotes: 25.5.8 -> 25.5.10 ``                                                             |
| [`5bdc63d4`](https://github.com/NixOS/nixpkgs/commit/5bdc63d4f955f25a1d83d07cca7f3315134ef7f0) | `` python3Packages.asf-search: 8.1.4 -> 8.2.3 ``                                               |
| [`05649cdf`](https://github.com/NixOS/nixpkgs/commit/05649cdfa5cdeb072fbcf92f892a00665a6fefe3) | `` turbovnc: remove zlib reference ``                                                          |
| [`5d737e24`](https://github.com/NixOS/nixpkgs/commit/5d737e24b07f81ce92190649d2f68f8a70d47ed7) | `` lasuite-docs-collaboration-server: init at 3.3.0 ``                                         |
| [`d2c305e2`](https://github.com/NixOS/nixpkgs/commit/d2c305e28877c28c64287aab6bd344fad95aa931) | `` lasuite-docs-frontend: init at 3.3.0 ``                                                     |
| [`d2cf4b94`](https://github.com/NixOS/nixpkgs/commit/d2cf4b948f42b350fce8317e2148bef482c1a69e) | `` lasuite-docs: init at 3.3.0 ``                                                              |
| [`2e2e96f1`](https://github.com/NixOS/nixpkgs/commit/2e2e96f1f568efb21cef66818ecc6ac1953b5a27) | `` kak-tree-sitter-unwrapped: 1.1.3 -> 2.0.0 ``                                                |
| [`138393e0`](https://github.com/NixOS/nixpkgs/commit/138393e0bab1c6cd9a78aeba8dd196065cf1eefd) | `` ci/eval.combine: avoid parsing of plain text file into JSON ``                              |
| [`d87d760d`](https://github.com/NixOS/nixpkgs/commit/d87d760dfa6128c51e8248458029b08778726a69) | `` ci/eval.compare: use lib from pinned nixpkgs ``                                             |
| [`eccd9564`](https://github.com/NixOS/nixpkgs/commit/eccd9564abe5de9d9931f974dc0fe68887b73a96) | `` ci/eval: improve api when calling in steps ``                                               |
| [`82396d1f`](https://github.com/NixOS/nixpkgs/commit/82396d1f484e96c60c11809a0f5df3b7208be34e) | `` workflows/{codeowners,eval}: move env before run ``                                         |
| [`b96dd19d`](https://github.com/NixOS/nixpkgs/commit/b96dd19d7a5f90ffb5bd3170e3c50757384ea096) | `` python3Packages.gql: 3.5.0 -> 3.5.3 ``                                                      |
| [`78481e65`](https://github.com/NixOS/nixpkgs/commit/78481e65b74b71588ac1a3b0254c61f74530a09e) | `` iosevka-bin: 33.2.2 -> 33.2.3 ``                                                            |
| [`a22a61f6`](https://github.com/NixOS/nixpkgs/commit/a22a61f6bcc5320ee2ec59b988ed089758c8427b) | `` rstudio: fix .desktop file by properly escaping use of cmake variable ``                    |
| [`e0d3828e`](https://github.com/NixOS/nixpkgs/commit/e0d3828e91f752b6084876861f621ba22f7c7a1c) | `` mdfried: init at 0.12.1 ``                                                                  |
| [`856cb310`](https://github.com/NixOS/nixpkgs/commit/856cb3108ac6fbf9a833c23e745dd2af868f869d) | `` OWNERS: add myself to `lib/licenses.nix` ``                                                 |
| [`c5d1ccd4`](https://github.com/NixOS/nixpkgs/commit/c5d1ccd473148df373b253a9deb32fd1a8ff5344) | `` atuin: fix systemd after/wants targets ``                                                   |
| [`bb05bee4`](https://github.com/NixOS/nixpkgs/commit/bb05bee4e5f3a987bf83b537fdebb6c1198a7783) | `` nixosTests.mycelium: make less flaky ``                                                     |
| [`d9e4682f`](https://github.com/NixOS/nixpkgs/commit/d9e4682fd40b988798c91bca24468d9f83230247) | `` zig: 0.14.0 -> 0.14.1 ``                                                                    |
| [`31bd988f`](https://github.com/NixOS/nixpkgs/commit/31bd988fd44e9798b01f63904f873942cae08f29) | `` brush: 0.2.17 -> 0.2.18 ``                                                                  |
| [`7a7dad34`](https://github.com/NixOS/nixpkgs/commit/7a7dad344b2aa54c648b493707d6844e11f61cc7) | `` typst: set version explicitly ``                                                            |
| [`1e43d85c`](https://github.com/NixOS/nixpkgs/commit/1e43d85c3e09ce042269a035f2640ee475a70dd5) | `` python312Packages.tinygrad: skip failing test ``                                            |
| [`a7158d09`](https://github.com/NixOS/nixpkgs/commit/a7158d09dcd706dd56e11811e1579e8233c31aea) | `` python312Packages.onnxmltools: cleanup, fix build ``                                        |
| [`aee81dfd`](https://github.com/NixOS/nixpkgs/commit/aee81dfd3766cc923a3a9c378dd1e810c9360e88) | `` nix-search-tv: 2.1.6 -> 2.1.7 ``                                                            |
| [`c6fd5166`](https://github.com/NixOS/nixpkgs/commit/c6fd516649e2da02c4609815216519fa5ed0b4ac) | `` python312Packages.onnxruntime-tools: cleanup ``                                             |
| [`a2e7a3c2`](https://github.com/NixOS/nixpkgs/commit/a2e7a3c2f99228f645e2bfe779b48a6dbe75531e) | `` python312Packages.onnx: 1.17.0 -> 1.18.0 ``                                                 |
| [`ada0f1fb`](https://github.com/NixOS/nixpkgs/commit/ada0f1fb281ea239b10cc9a736616ef38977c701) | `` vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.99.2025041609 -> 1.100.2025051409 `` |
| [`edc314c9`](https://github.com/NixOS/nixpkgs/commit/edc314c9c9aec817beda213029e6e8badbf1397a) | `` vscode-extensions.scalameta.metals: 1.50.0 -> 1.51.0 ``                                     |
| [`5d599101`](https://github.com/NixOS/nixpkgs/commit/5d599101f53e88579a9fe35355b4f13b1015acbc) | `` mergiraf: 0.8.0 -> 0.8.1 ``                                                                 |
| [`ac805ff8`](https://github.com/NixOS/nixpkgs/commit/ac805ff8fa07c35ce50191231bfe5d3b74fcff1e) | `` trayscale: 0.16.0 -> 0.18.0 ``                                                              |
| [`4a1b7155`](https://github.com/NixOS/nixpkgs/commit/4a1b7155e8f3cfe4454430a3ed83d0eb773c828e) | `` lnd: 0.18.5 -> 0.19.0 ``                                                                    |
| [`d944d582`](https://github.com/NixOS/nixpkgs/commit/d944d582c02035401cb82c883e71327fb25dde15) | `` ac-library: 1.5.1 -> 1.6 ``                                                                 |
| [`59dff5cf`](https://github.com/NixOS/nixpkgs/commit/59dff5cf0a3f25e434505c8b248895701f26f6fc) | `` terminator: 2.1.4 -> 2.1.5 ``                                                               |
| [`0ea94c8c`](https://github.com/NixOS/nixpkgs/commit/0ea94c8c02b5a5da6728fbc4b544005e6a779995) | `` home-manager: 0-unstable-2025-05-13 -> 0-unstable-2025-05-23 ``                             |
| [`7f298b2a`](https://github.com/NixOS/nixpkgs/commit/7f298b2a65644b3dde8d92b2b5d444aa61e76b09) | `` fastfetch: 2.43.0 -> 2.44.0 ``                                                              |
| [`398940fa`](https://github.com/NixOS/nixpkgs/commit/398940fa0ac647a4b7ac9aa01689d5b10e78bdeb) | `` tootik: 0.16.0 -> 0.16.1 ``                                                                 |
| [`d948f92e`](https://github.com/NixOS/nixpkgs/commit/d948f92ed3106de124c1dd0566d7ee6b8e848ecf) | `` python3Packages.notobuilder: 0-unstable-2025-04-28 -> 0-unstable-2025-05-20 ``              |
| [`5a621f79`](https://github.com/NixOS/nixpkgs/commit/5a621f79f32072cf6f39631ca407ed3635031900) | `` home-assistant-custom-components.versatile_thermostat: 7.3.0 -> 7.3.1 ``                    |
| [`26bfe1ba`](https://github.com/NixOS/nixpkgs/commit/26bfe1bacce7af3171513adb148ab91d7c20575a) | `` uv: 0.7.7 -> 0.7.8 ``                                                                       |
| [`568b9ae4`](https://github.com/NixOS/nixpkgs/commit/568b9ae4f7199e9779a7156894bac96a6e0d55d6) | `` atlas: 0.33.0 -> 0.33.1 ``                                                                  |
| [`1ef83944`](https://github.com/NixOS/nixpkgs/commit/1ef83944095e8fbafbee45585e64bf6b0f0b39db) | `` kohighlights: remove double wrapping, use pyproject = false ``                              |
| [`19acb808`](https://github.com/NixOS/nixpkgs/commit/19acb808050baf1ae26fc3f8f0ee2b263d45509e) | `` guix: add hpfr to meta.maintainers ``                                                       |
| [`5f72371b`](https://github.com/NixOS/nixpkgs/commit/5f72371b4d50fbb0a7e6b4074938e25861fa4417) | `` maintainers: add hpfr ``                                                                    |
| [`e67aaa32`](https://github.com/NixOS/nixpkgs/commit/e67aaa327a4dbeca5c0384c320400e12a887acb9) | `` parabolic: patch out bypassing wrapped executables ``                                       |
| [`f4ad89e4`](https://github.com/NixOS/nixpkgs/commit/f4ad89e41e840d43f75ccfb59d98772fde953eed) | `` guix: Fix guile-ssh detection ``                                                            |
| [`8892a5dc`](https://github.com/NixOS/nixpkgs/commit/8892a5dcb6b19b304f6d1aa1dc2b0b3fba3e5b78) | `` guix: Fix guile-ssh library load ``                                                         |
| [`d80991f4`](https://github.com/NixOS/nixpkgs/commit/d80991f44ce8e743324f243573a5df643ed73674) | `` jetbrains-jdk: 21.0.4 -> 21.0.6 ``                                                          |
| [`235524a5`](https://github.com/NixOS/nixpkgs/commit/235524a5ce5facc3fe486018fd4fb815b25c4b46) | `` python3Packages.pysqueezebox: 0.12.0 -> 0.12.1 ``                                           |
| [`d58570f1`](https://github.com/NixOS/nixpkgs/commit/d58570f1675011ba34b04d54d1935dd4221ca281) | `` mycelium: 0.6.0 -> 0.6.1 ``                                                                 |
| [`bb23492d`](https://github.com/NixOS/nixpkgs/commit/bb23492d23460e00c4aff751d51ba04d2397da36) | `` doc/rl2505: move variants to 25.05 ``                                                       |
| [`139cfe9d`](https://github.com/NixOS/nixpkgs/commit/139cfe9d062747efa027b009a214f057affd6cb2) | `` openusd: propagate opensubdiv ``                                                            |
| [`15c77275`](https://github.com/NixOS/nixpkgs/commit/15c772758920995779ffc6f2a60c0ab11452b9b3) | `` python3Packages.docling-serve: 0.10.1 -> 0.11.0 ``                                          |
| [`9f781f41`](https://github.com/NixOS/nixpkgs/commit/9f781f41dfb3f81ddfeb8db814910e8ca490ad84) | `` museum: copy web-templates to output ``                                                     |
| [`833514ae`](https://github.com/NixOS/nixpkgs/commit/833514ae8a0a25d1065981ce4b35c96e0a0e6857) | `` libretro.genesis-plus-gx: 0-unstable-2025-05-02 -> 0-unstable-2025-05-23 ``                 |
| [`0d807ed8`](https://github.com/NixOS/nixpkgs/commit/0d807ed81ed0bfe9e5ae5888a9059dd4fcbb7eb5) | `` python3Packages.pyoverkiz: 1.17.1 -> 1.17.2 ``                                              |
| [`cb29e962`](https://github.com/NixOS/nixpkgs/commit/cb29e962c109a58a98dfb6f8d9068ce42711b107) | `` rPackages.dataverse: fix build ``                                                           |
| [`559c4d01`](https://github.com/NixOS/nixpkgs/commit/559c4d01332b5fd739c28534d72d0be57bfdbf39) | `` nixos/gerrit: Pin Java version to 21 ``                                                     |
| [`773a7561`](https://github.com/NixOS/nixpkgs/commit/773a75618dec939aaef706b48be71cfd61966565) | `` rPackages.terra: fix build ``                                                               |
| [`d65cae20`](https://github.com/NixOS/nixpkgs/commit/d65cae200824828127a05ebb4673f085b7985d63) | `` python3Packages.langgraph-checkpoint-postgres: Disable flaky test ``                        |
| [`51ffe732`](https://github.com/NixOS/nixpkgs/commit/51ffe73225da81059a4c1ce21bdd197ab2debe9a) | `` python3Packages.mkdocs-autorefs: 1.4.1 -> 1.4.2 ``                                          |
| [`680dda8c`](https://github.com/NixOS/nixpkgs/commit/680dda8cf1f6efce2affeb2aeeb3f9d089c90e48) | `` dust: add defelo as maintainer ``                                                           |
| [`813693e4`](https://github.com/NixOS/nixpkgs/commit/813693e40cb544e0678533e55cda2a0ce2f01560) | `` dust: enable tests ``                                                                       |
| [`5f87ec2e`](https://github.com/NixOS/nixpkgs/commit/5f87ec2ef17a30231d17dedf4e822d71465abe6f) | `` python3Packages.dissect-hypervisor: 3.17 -> 3.18 ``                                         |
| [`ab64676e`](https://github.com/NixOS/nixpkgs/commit/ab64676e8139e6a5a4570b3b83478a5184fd38df) | `` harper: 0.36.0 -> 0.38.0 ``                                                                 |