### PR TITLE
chore(flake/nixpkgs): `edb3633f` -> `bdac72d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748123162,
-        "narHash": "sha256-1fROmP+xlRkSiZ2bTH9JM6b4NUREhCerESEKQBKBkEw=",
+        "lastModified": 1748186667,
+        "narHash": "sha256-UQubDNIQ/Z42R8tPCIpY+BOhlxO8t8ZojwC9o2FW3c8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "edb3633f9100d9277d1c9af245a4e9337a980c07",
+        "rev": "bdac72d387dca7f836f6ef1fe547755fb0e9df61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`f1c69b60`](https://github.com/NixOS/nixpkgs/commit/f1c69b60ad81d9942207698bbf776273de6c3b4d) | `` dclib: remove ``                                                                          |
| [`0e1c284b`](https://github.com/NixOS/nixpkgs/commit/0e1c284b1321a3a2cacf96068fdba7b59ed0602b) | `` workflows: checkout nixpkgs in get-merge-commit action ``                                 |
| [`942c3774`](https://github.com/NixOS/nixpkgs/commit/942c377476675848155e860b9d41d869589b8a47) | `` workflows/nixpkgs-vet: use nixpkgs-vet from pinned nixpkgs ``                             |
| [`c8d36fe7`](https://github.com/NixOS/nixpkgs/commit/c8d36fe7be9ef579621f5f560eecdd09df2e0440) | `` nexusmods-app: 0.10.2 -> 0.11.3 ``                                                        |
| [`c47da7fb`](https://github.com/NixOS/nixpkgs/commit/c47da7fbc81ed640a7a26ea37dbd1ea108eb92a2) | `` doc/rl-2505: reword nexusmods-app entry ``                                                |
| [`94c59406`](https://github.com/NixOS/nixpkgs/commit/94c59406f9c01e3d0961ef12a9ca01e9cebc43a4) | `` doc/rl-2505: move nexusmods-app entry back to "incompatibilities" ``                      |
| [`6720d254`](https://github.com/NixOS/nixpkgs/commit/6720d254294220cdfce18c3f981a8aabffb3de94) | `` workflows: checkout nixpkgs into trusted/untrusted directories ``                         |
| [`539e8d4f`](https://github.com/NixOS/nixpkgs/commit/539e8d4f66323b87aa1b8e715ec01b9f5199ca82) | `` actions/get-merge-conflict: refactor ``                                                   |
| [`cd9a22d7`](https://github.com/NixOS/nixpkgs/commit/cd9a22d7530baf33890971b01af8798069c3fea9) | `` workflows/eval: fix comparison with merge conflicts ``                                    |
| [`a81cfab9`](https://github.com/NixOS/nixpkgs/commit/a81cfab95226f0e2945a5068edb566dd28b2cc6e) | `` openvscode-server: 1.88.1 -> 1.99.3; unbreak ``                                           |
| [`35df7fd7`](https://github.com/NixOS/nixpkgs/commit/35df7fd7276c6197364aff797f577fae7d7dc887) | `` openvscode-server: add bendlas as maintainer ``                                           |
| [`4bd7a015`](https://github.com/NixOS/nixpkgs/commit/4bd7a0155f8fd5f3d0ec12abb1d4915cd42bc23c) | `` servo: 0-unstable-2025-05-15 -> 0-unstable-2025-05-25 ``                                  |
| [`c5f35290`](https://github.com/NixOS/nixpkgs/commit/c5f3529083d802375f4851bb2a5f10c528fc6486) | `` python3Packages.flufl-lock: 8.1.0 -> 8.2.0 ``                                             |
| [`96c3a525`](https://github.com/NixOS/nixpkgs/commit/96c3a525927c3e484e5105dcd37f71e0b8e14d68) | `` gtkmm3: update homepage ``                                                                |
| [`ab979f47`](https://github.com/NixOS/nixpkgs/commit/ab979f479674883b70e37dc7bc8bb19daefe76d7) | `` libretro.mgba: 0-unstable-2025-02-17 -> 0-unstable-2025-05-18 ``                          |
| [`c2509dc9`](https://github.com/NixOS/nixpkgs/commit/c2509dc9db837388da9664479b824f2dc08ea3b6) | `` python3Packages.optimum: update optional dependencies ``                                  |
| [`ae1c56ad`](https://github.com/NixOS/nixpkgs/commit/ae1c56ad7fbcf88c9899c3c83f0db258d339ef8d) | `` python3Packages.optimum: 1.24.0 -> 1.25.3 ``                                              |
| [`aa852f23`](https://github.com/NixOS/nixpkgs/commit/aa852f2301984fb797532cc18aa050b6a3ee694b) | `` cloud-hypervisor: 45.0 -> 46.0 ``                                                         |
| [`18dc2804`](https://github.com/NixOS/nixpkgs/commit/18dc2804822355cc02d63d862973eb3d60d3f4c2) | `` python3Packages.testresources: 2.0.1 -> 2.0.2 ``                                          |
| [`dd082b81`](https://github.com/NixOS/nixpkgs/commit/dd082b8161531372f6746da0859f62a17dbe814f) | `` jenkins: 2.492.3 -> 2.504.1 ``                                                            |
| [`d0f4918a`](https://github.com/NixOS/nixpkgs/commit/d0f4918a8ab578bf2813a5d8fd126752f8cca033) | `` lunar-client: 3.3.7 -> 3.3.8 ``                                                           |
| [`f57fbc28`](https://github.com/NixOS/nixpkgs/commit/f57fbc289bb4167a9606b2bb6feb653d73fa9357) | `` roddhjav-apparmor-rules: 0-unstable-2025-05-14 -> 0-unstable-2025-05-20 ``                |
| [`eb3dd361`](https://github.com/NixOS/nixpkgs/commit/eb3dd361dad7dbec937de5e3919fa08b17e1adad) | `` niri: 25.05 -> 25.05.1 ``                                                                 |
| [`fd25cbd7`](https://github.com/NixOS/nixpkgs/commit/fd25cbd7596cd8a6a338fcbbc1e91457b90fe7b6) | `` postgres-lsp: 0.6.0 -> 0.7.0 ``                                                           |
| [`975c19cb`](https://github.com/NixOS/nixpkgs/commit/975c19cb475dd1ca85453c8635a8b089f6b9a693) | `` nixos/scrutiny: change collector schedule to daily ``                                     |
| [`25d2690f`](https://github.com/NixOS/nixpkgs/commit/25d2690f74d0d69b28ae4b4847619c39ba684b5f) | `` borgmatic: 2.0.5 -> 2.0.6 ``                                                              |
| [`1f316344`](https://github.com/NixOS/nixpkgs/commit/1f3163445011b667ea5ba8316b96a24c107f1802) | `` github-mcp-server: 0.3.0 -> 0.4.0 ``                                                      |
| [`65874600`](https://github.com/NixOS/nixpkgs/commit/658746009918ba76df5f475259be8a9133afbd52) | `` typstyle: 0.13.8 -> 0.13.9 ``                                                             |
| [`69c74cb4`](https://github.com/NixOS/nixpkgs/commit/69c74cb4387e5aa88d0c0443782b9fa6bd8469e2) | `` python3Packages.snakemake-storage-plugin-fs: 1.1.1 -> 1.1.2 ``                            |
| [`b5410fd1`](https://github.com/NixOS/nixpkgs/commit/b5410fd1d414491c1394c2af13492a15bc5e4e4d) | `` flashprog: Add changelog link to meta information ``                                      |
| [`ab80816d`](https://github.com/NixOS/nixpkgs/commit/ab80816d9270654c3776100ad8e4df32d1d89474) | `` naev: 0.12.4 -> 0.12.5 ``                                                                 |
| [`e66f3478`](https://github.com/NixOS/nixpkgs/commit/e66f34783ebac25be3bd791dbdd3e933baf6f0af) | `` treewide: substitute pname for strings (python3Packages.[a-g].*) ``                       |
| [`e5782299`](https://github.com/NixOS/nixpkgs/commit/e5782299ea225ff7ab238495edbfcee857df6d1e) | `` glamoroustoolkit: 1.1.22 -> 1.1.24 ``                                                     |
| [`00eb1a7f`](https://github.com/NixOS/nixpkgs/commit/00eb1a7f781eb10aa39076fdc29c5bb6fd0bcead) | `` telegraf: 1.34.3 -> 1.34.4 ``                                                             |
| [`a66500f7`](https://github.com/NixOS/nixpkgs/commit/a66500f738266333c6f5fcc963f110a8417b0830) | `` python3Packages.types-typed-ast: drop ``                                                  |
| [`813189a9`](https://github.com/NixOS/nixpkgs/commit/813189a99f1836b48b86340b672659bd24498003) | `` nixosTests.lomiri-mediaplayer-app: Optimise OCR ``                                        |
| [`fb7f603d`](https://github.com/NixOS/nixpkgs/commit/fb7f603d2db140375fe9ba774fa0147e888ff52d) | `` python3Packages.typed-ast: drop ``                                                        |
| [`e2928d8b`](https://github.com/NixOS/nixpkgs/commit/e2928d8bc9d13ef8bfb9c14ae3e282dae0a2e921) | `` python3Packages.aiosonic: remove unused dependencies ``                                   |
| [`45991097`](https://github.com/NixOS/nixpkgs/commit/45991097c5140990575ff61aa05d9604c1258ada) | `` manual: Use a `postPatch` instead of a `patchPhase` ``                                    |
| [`b0005689`](https://github.com/NixOS/nixpkgs/commit/b0005689544930e3d0085a04f998d29c9603f3bc) | `` libretro.play: 0-unstable-2025-05-09 -> 0-unstable-2025-05-23 ``                          |
| [`5e6bbf4e`](https://github.com/NixOS/nixpkgs/commit/5e6bbf4edaba355af9034484d338d613f07aa8e4) | `` python313Packages.reflex-chakra: 0.7.0 -> 0.7.1 ``                                        |
| [`17f60e67`](https://github.com/NixOS/nixpkgs/commit/17f60e675e7f2234e5365eecd73bb1937bfcbde6) | `` python313Packages.androidtvremote2: 0.2.1 -> 0.2.2 ``                                     |
| [`e7f1f6f7`](https://github.com/NixOS/nixpkgs/commit/e7f1f6f7e165d118e43a9eaf60aca78429717cea) | `` rattler-build: 0.41.0 -> 0.42.1 ``                                                        |
| [`a6dab786`](https://github.com/NixOS/nixpkgs/commit/a6dab786438e3ec31c159896a312e74e8e30829c) | `` python3Packages.types-psycopg2: 2.9.21.20250318 -> 2.9.21.20250516 ``                     |
| [`0622d5fd`](https://github.com/NixOS/nixpkgs/commit/0622d5fd0245fa0c0962f8cdcd4440232df772ce) | `` sleek: 0.3.0 -> 0.4.0 ``                                                                  |
| [`e380e29c`](https://github.com/NixOS/nixpkgs/commit/e380e29c67e4da103e50eca6ef9cff24ddbb8353) | `` ghostfolio: 2.161.0 -> 2.162.0 ``                                                         |
| [`d10660b9`](https://github.com/NixOS/nixpkgs/commit/d10660b946be542749deb7eacbf8c68dd84f191e) | `` tpnote: 1.25.9 -> 1.25.10 ``                                                              |
| [`e9f87be2`](https://github.com/NixOS/nixpkgs/commit/e9f87be223fda88844f60930af32480a329958ac) | `` tflint: 0.57.0 -> 0.58.0 ``                                                               |
| [`3f90d5b9`](https://github.com/NixOS/nixpkgs/commit/3f90d5b9065e1d481da76205fa807e56b6892933) | `` touchegg: 2.0.17 -> 2.0.18 ``                                                             |
| [`441f5a13`](https://github.com/NixOS/nixpkgs/commit/441f5a13acfbe391960756cc56796eb341f0a8e1) | `` nelm: 1.4.0 -> 1.4.1 ``                                                                   |
| [`a5a7b272`](https://github.com/NixOS/nixpkgs/commit/a5a7b272ee007aabade4b6e89c7609bc9ac88b0f) | `` komikku: 1.76.1 -> 1.77.0 ``                                                              |
| [`020c1daa`](https://github.com/NixOS/nixpkgs/commit/020c1daaf9062c0066f43646bd8b86b562b412a7) | `` python3Packages.type-infer: pkgs.symlinkJoin -> python3Packages.nltk.dataDir ``           |
| [`8aa49dac`](https://github.com/NixOS/nixpkgs/commit/8aa49dac246c0ff3657823556fd6b52534cf6aed) | `` python3Packages.aider-chat: pkgs.symlinkJoin -> python3Packages.nltk.dataDir ``           |
| [`0bb5be9a`](https://github.com/NixOS/nixpkgs/commit/0bb5be9addc86bff92d3ede45ec094755055cba5) | `` unstructured-api: pkgs.symlinkJoin -> python.pkgs.nltk.dataDir ``                         |
| [`279f2c03`](https://github.com/NixOS/nixpkgs/commit/279f2c0308682c2177595cc3af6d1e26fc084160) | `` python3Packages.nltk: run tests ``                                                        |
| [`acc6352e`](https://github.com/NixOS/nixpkgs/commit/acc6352eeb3e1b4fb10f6d17954bc0eb4edf07f7) | `` python3Packages.nltk: propagatedBuildInputs -> dependencies ``                            |
| [`aee430ee`](https://github.com/NixOS/nixpkgs/commit/aee430ee47e1e80e4d555722e3d6ba1bf7899c00) | `` python3Packages.nltk.dataDir: init ``                                                     |
| [`9562488e`](https://github.com/NixOS/nixpkgs/commit/9562488efb1b8e2d60e60203e9ea752c131cad2c) | `` python3Packages.nltk.data: access `nltk-data` packages via `passthru` ``                  |
| [`c9caba6f`](https://github.com/NixOS/nixpkgs/commit/c9caba6f7d6d0d768246ff72f877733be5f35a60) | `` python3Packages.nltk: add bengsparks to maintainers ``                                    |
| [`77353d78`](https://github.com/NixOS/nixpkgs/commit/77353d78711d7496f282f7330b471b0c5e5a6023) | `` mint-themes: 2.2.3 -> 2.2.6 ``                                                            |
| [`55b8857b`](https://github.com/NixOS/nixpkgs/commit/55b8857bc1384237bfdb0289b5a6fc094473da23) | `` pantheon.elementary-notifications: 8.0.0 -> 8.1.0 ``                                      |
| [`af93b70d`](https://github.com/NixOS/nixpkgs/commit/af93b70ddcccc8cb429f486d7938cba33d8b6401) | `` nixos/boot: add boot.tmp.useZram options ``                                               |
| [`6c3175a0`](https://github.com/NixOS/nixpkgs/commit/6c3175a04289d9564cc1572a6b336ae8430591a3) | `` smatch: fix build by applying custom fix ``                                               |
| [`245edb75`](https://github.com/NixOS/nixpkgs/commit/245edb755d351b3a33ae3e3e0f292b9794ee1cb4) | `` nototools: remove unused dependency ``                                                    |
| [`19855938`](https://github.com/NixOS/nixpkgs/commit/19855938fc607e36c1c7209a7eda1651981f3523) | `` nototools: move to top-level ``                                                           |
| [`fd6f086c`](https://github.com/NixOS/nixpkgs/commit/fd6f086ce306085ab4dfeead6fe681a51713aa5f) | `` xfce.xfce4-xkb-plugin: 0.8.5 -> 0.9.0 ``                                                  |
| [`68d2dfa8`](https://github.com/NixOS/nixpkgs/commit/68d2dfa8d67db7b598075a8b18ffb3b735be925c) | `` xfce.xfce4-windowck-plugin: 0.5.2 -> 0.6.0 ``                                             |
| [`09540994`](https://github.com/NixOS/nixpkgs/commit/09540994a0bb30cdad850cde92f40896d06da969) | `` xfce.xfce4-whiskermenu-plugin: 2.9.2 -> 2.10.0 ``                                         |
| [`e68f1b45`](https://github.com/NixOS/nixpkgs/commit/e68f1b45d4d241adc798535a232c4a455fc8baa2) | `` xfce.xfce4-weather-plugin: 0.11.3 -> 0.12.0 ``                                            |
| [`b9ad8620`](https://github.com/NixOS/nixpkgs/commit/b9ad8620b1b87e8356a527c8eba61e097b0f5db8) | `` xfce.xfce4-verve-plugin: 2.0.4 -> 2.1.0 ``                                                |
| [`9007ca07`](https://github.com/NixOS/nixpkgs/commit/9007ca07f5ceace0b1567b691edd29ab01518285) | `` xfce.xfce4-timer-plugin: 1.7.3 -> 1.8.0 ``                                                |
| [`961f336e`](https://github.com/NixOS/nixpkgs/commit/961f336e8cc6c37f79ca65f26ca375c0ceca45e9) | `` exaile: 4.1.3 -> 4.1.4 ``                                                                 |
| [`ee6c2bd2`](https://github.com/NixOS/nixpkgs/commit/ee6c2bd2eb1345e00fa65ff69ea9a0481a8406ef) | `` doc: Fix missing pre/post hooks everywhere ``                                             |
| [`66654e9f`](https://github.com/NixOS/nixpkgs/commit/66654e9fc97ce272979d7f5796df53b6497f2d69) | `` nodePackages.prettier: Add version test ``                                                |
| [`0347dd0b`](https://github.com/NixOS/nixpkgs/commit/0347dd0bcfcd10705428b7f296d6d497fe755469) | `` python313Packages.boto3-stubs: 1.38.22 -> 1.38.23 ``                                      |
| [`c4480a19`](https://github.com/NixOS/nixpkgs/commit/c4480a19f506159ac2cfb165999679ed7bd0950c) | `` python312Packages.mypy-boto3-ec2: 1.38.21 -> 1.38.23 ``                                   |
| [`afda1127`](https://github.com/NixOS/nixpkgs/commit/afda1127d595e6c76859e6ecb3b56ec5a6765c49) | `` gradle: 8.14 -> 8.14.1 ``                                                                 |
| [`f3d50d54`](https://github.com/NixOS/nixpkgs/commit/f3d50d54764475ce675ffb9291365c4a732089ae) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.245 -> 0.13.246 `` |
| [`babb4f7f`](https://github.com/NixOS/nixpkgs/commit/babb4f7fe7d809138126470eef373c23004752d8) | `` python313Packages.homeassistant-stubs: 2025.5.2 -> 2025.5.3 ``                            |
| [`5ac5726b`](https://github.com/NixOS/nixpkgs/commit/5ac5726b8034c59c763308718645875fdaf0972a) | `` morgen: 3.6.13 -> 3.6.14 ``                                                               |
| [`2bfe49e3`](https://github.com/NixOS/nixpkgs/commit/2bfe49e3973641f38e0b6f8a8b37f17f4d3a3dee) | `` home-assistant: 2025.5.2 -> 2025.5.3 ``                                                   |
| [`cd3db0e7`](https://github.com/NixOS/nixpkgs/commit/cd3db0e7a79fc08c2cdfd931fbce857716752ef6) | `` thunderbird-esr-bin-unwrapped: 128.10.1esr -> 128.10.2esr ``                              |
| [`6edb0dd3`](https://github.com/NixOS/nixpkgs/commit/6edb0dd30bca2b69a2003becee5310b1883c9fd0) | `` python313Packages.deebot-client: 13.2.0 -> 13.2.1 ``                                      |
| [`2e09de20`](https://github.com/NixOS/nixpkgs/commit/2e09de2007eca924bb45e4f3328d77cde71bc8a3) | `` python313Packages.pysqueezebox: 0.12.0 -> 0.12.1 ``                                       |
| [`7d7e1dd5`](https://github.com/NixOS/nixpkgs/commit/7d7e1dd5a3e911498e5ef680e975edb497326855) | `` python313Packages.pylamarzocco: 2.0.3 -> 2.0.4 ``                                         |
| [`ae1a9fd1`](https://github.com/NixOS/nixpkgs/commit/ae1a9fd15dabcf9f226fc95374a7d6099fe8fb7b) | `` python313Packages.py-synologydsm-api: 2.7.1 -> 2.7.2 ``                                   |
| [`b061acba`](https://github.com/NixOS/nixpkgs/commit/b061acba4cedb739faa773ffe001d38af088333d) | `` linux/hardened/patches/6.6: v6.6.90-hardened1 -> v6.6.91-hardened1 ``                     |
| [`6dfe996e`](https://github.com/NixOS/nixpkgs/commit/6dfe996ec1e246e173b73194a8be0533bf982663) | `` linux/hardened/patches/6.14: v6.14.6-hardened1 -> v6.14.7-hardened1 ``                    |
| [`f07903a0`](https://github.com/NixOS/nixpkgs/commit/f07903a00be7a017533534318a53ae982e719f4c) | `` linux/hardened/patches/6.12: v6.12.28-hardened1 -> v6.12.29-hardened1 ``                  |
| [`39e8a051`](https://github.com/NixOS/nixpkgs/commit/39e8a0516816f96f35f9d0b139b11a9dd9c460a1) | `` linux/hardened/patches/6.1: v6.1.138-hardened1 -> v6.1.139-hardened1 ``                   |
| [`ddde68fb`](https://github.com/NixOS/nixpkgs/commit/ddde68fb87909d89f57196ac33f00498670a56b8) | `` linux/hardened/patches/5.15: v5.15.182-hardened1 -> v5.15.183-hardened1 ``                |
| [`35ab705f`](https://github.com/NixOS/nixpkgs/commit/35ab705fff6f4c1b2dca0125347db3d80b358e62) | `` linux_latest-libre: 19792 -> 19795 ``                                                     |
| [`f49642dc`](https://github.com/NixOS/nixpkgs/commit/f49642dccc26790506173ad72af67d1faff77c09) | `` linux-rt_5_15: 5.15.179-rt84 -> 5.15.183-rt85 ``                                          |
| [`e49bc990`](https://github.com/NixOS/nixpkgs/commit/e49bc99039571d3fe9304339aa2572f5996e5c12) | `` python3Packages.google-genai: 1.15.0 -> 1.16.1 ``                                         |
| [`3ce945c0`](https://github.com/NixOS/nixpkgs/commit/3ce945c042c6a5a2d346d2562c992f87daef1b4c) | `` mdbook: 0.4.49 -> 0.4.50 ``                                                               |
| [`089eeb46`](https://github.com/NixOS/nixpkgs/commit/089eeb4610c279c53aea84488802fe5920717a9a) | `` lomiri.lomiri-mediaplayer-app: 1.1.0 -> 1.1.1 ``                                          |
| [`982c068a`](https://github.com/NixOS/nixpkgs/commit/982c068a64b0aeaf7389f45f743de88dff91742e) | `` python3Packages.xcffib: 1.7.1 -> 1.9.0 ``                                                 |
| [`ce776223`](https://github.com/NixOS/nixpkgs/commit/ce7762236b590b7877c2d070192faca6bc1c4db8) | `` naev: 0.11.5 -> 0.12.4 ``                                                                 |
| [`28eb5dec`](https://github.com/NixOS/nixpkgs/commit/28eb5dec4b034989cf758f74a1ea976c9c43594d) | `` signal-desktop-bin: fix update script for darwin ``                                       |
| [`f36c5649`](https://github.com/NixOS/nixpkgs/commit/f36c564937b99661a74e2343b4291043b33079a7) | `` signal-desktop-bin: adjust update-script for aarch64-linux ``                             |
| [`869289b1`](https://github.com/NixOS/nixpkgs/commit/869289b1bac186f058afa8de5ecbb7fe0695ac67) | `` signal-desktop(darwin): 7.52.0 -> 7.55.0 ``                                               |
| [`1ca8ec60`](https://github.com/NixOS/nixpkgs/commit/1ca8ec60b04d7c274be11d9f8e1858ac469fc85b) | `` signal-desktop(aarch64-linux): 7.52.0 -> 7.55.0 ``                                        |
| [`73f10046`](https://github.com/NixOS/nixpkgs/commit/73f10046fc138a35e0ea031e882d0715c2cb82a5) | `` xh: add defelo as maintainer ``                                                           |
| [`66516a0b`](https://github.com/NixOS/nixpkgs/commit/66516a0bf58891769286e0b07fd91e6ec9ea9647) | `` xh: add updateScript ``                                                                   |
| [`e13c1026`](https://github.com/NixOS/nixpkgs/commit/e13c1026dc25b8c9fdc11faf342196272f322b3a) | `` xh: add versionCheckHook ``                                                               |
| [`ad50a011`](https://github.com/NixOS/nixpkgs/commit/ad50a01127baca230022ad58d1aae29be8688f40) | `` xh: use tag in fetchFromGitHub ``                                                         |
| [`6ad3370c`](https://github.com/NixOS/nixpkgs/commit/6ad3370cf21b8784befa08307da7dfcb9516f7a8) | `` xh: use finalAttrs pattern ``                                                             |
| [`10f39b09`](https://github.com/NixOS/nixpkgs/commit/10f39b09369595278caae7e61e91b004932186b0) | `` bpftrace: 0.23.2 -> 0.23.3 ``                                                             |
| [`dff26b81`](https://github.com/NixOS/nixpkgs/commit/dff26b810ac18f2bdd82a74adf5576da8a0984ab) | `` oci-cli: 3.55.0 -> 3.56.1 ``                                                              |
| [`e32b9fce`](https://github.com/NixOS/nixpkgs/commit/e32b9fce64f7051979ca9078d5ac276383c0cf9e) | `` python313Packages.sanic: 24.12.0 -> 25.3.0 ``                                             |
| [`70620808`](https://github.com/NixOS/nixpkgs/commit/7062080823125e81da5132751e3b6b77511ddbf8) | `` zipline: 4.0.2 -> 4.1.0 ``                                                                |
| [`646caed8`](https://github.com/NixOS/nixpkgs/commit/646caed84fc41f912334f057d16621b9eaefa757) | `` python3Packages.condense-json: 0.1.2 -> 0.1.3 ``                                          |
| [`47ad31e3`](https://github.com/NixOS/nixpkgs/commit/47ad31e33a5a5bf49723e0a8e62c130612519d95) | `` pageedit: 2.0.0 -> 2.4.0 ``                                                               |
| [`ad282497`](https://github.com/NixOS/nixpkgs/commit/ad2824979b418caa0299f7ccc1abb13b51210322) | `` python3Packages.pypdf: 5.4.0 -> 5.5.0 ``                                                  |
| [`854f73bf`](https://github.com/NixOS/nixpkgs/commit/854f73bf8fd267d342ddc9fc0a29a19b1b04d26e) | `` python3Packages.langchain-core: 0.3.59 -> 0.3.60 ``                                       |
| [`ebdfe024`](https://github.com/NixOS/nixpkgs/commit/ebdfe024c292dde8e42ae6d3724a8860efc563c0) | `` python3Packages.bokeh: 3.7.2 -> 3.7.3 ``                                                  |
| [`22bdef77`](https://github.com/NixOS/nixpkgs/commit/22bdef776e9efdc55755ebea70a5b422a6307e68) | `` python3Packages.types-pytz: 2025.2.0.20250326 -> 2025.2.0.20250516 ``                     |
| [`4f6f1dfe`](https://github.com/NixOS/nixpkgs/commit/4f6f1dfeedbec7cd15626f424499da06f6651f22) | `` python3Packages.makefun: 1.15.6 -> 1.16.0 ``                                              |
| [`3ae75c4b`](https://github.com/NixOS/nixpkgs/commit/3ae75c4bab39831a1829ac3aad53199f3e9037a8) | `` containerd: 2.0.5 -> 2.1.0 ``                                                             |
| [`08de3692`](https://github.com/NixOS/nixpkgs/commit/08de36925ae42e7abf8c49e07eeaf1f0afcc086e) | `` python3Packages.icalendar: 6.1.3 -> 6.3.0 ``                                              |
| [`8ad53eba`](https://github.com/NixOS/nixpkgs/commit/8ad53eba468737af64f98d068e1894f619faf597) | `` netavark: 1.14.1 -> 1.15.0 ``                                                             |
| [`c6211353`](https://github.com/NixOS/nixpkgs/commit/c621135365c6be1f9dca22ca06a967c6eafce221) | `` tiledb: 2.27.2 -> 2.28.0 ``                                                               |
| [`dde3e32b`](https://github.com/NixOS/nixpkgs/commit/dde3e32b28bca8586148e14d8e273e0f538cadc6) | `` python3Packages.ijson: 3.3.0 -> 3.4.0 ``                                                  |
| [`2b0f385f`](https://github.com/NixOS/nixpkgs/commit/2b0f385fabbf7b605470d995543801bcadd92759) | `` python3Packages.markdownify: 0.14.1 -> 1.1.0 ``                                           |
| [`f56e9aa4`](https://github.com/NixOS/nixpkgs/commit/f56e9aa4f9f9e74f4bb53cca1728e99bbfc4e949) | `` python3Packages.pygit2: 1.17.0 -> 1.18.0 ``                                               |
| [`a21f9ef2`](https://github.com/NixOS/nixpkgs/commit/a21f9ef2300283be055f21cb306249e2ea243f8d) | `` python3Packages.fontparts: 0.12.3 -> 0.12.5 ``                                            |
| [`9b3a7f30`](https://github.com/NixOS/nixpkgs/commit/9b3a7f3047479d709aaac7d4da0eaacd93f6000a) | `` linuxPackages.ena: 2.13.3 -> 2.14.0 ``                                                    |
| [`e4633ab2`](https://github.com/NixOS/nixpkgs/commit/e4633ab264548740d9f4663114aeddd8e1c536e0) | `` mlt: 7.30.0 -> 7.32.0 ``                                                                  |
| [`0a51a163`](https://github.com/NixOS/nixpkgs/commit/0a51a163ca3eea7483244decefeee662dcde2694) | `` signal-desktop-bin: 7.52.0 -> 7.55.0 ``                                                   |
| [`281c0c16`](https://github.com/NixOS/nixpkgs/commit/281c0c16c9c6e2e44e78334f55bbd43dc51c0d70) | `` gcc15, gccgo15, gfortran15, gnat15: init at 15.1.0 ``                                     |
| [`814378b3`](https://github.com/NixOS/nixpkgs/commit/814378b3f4cd1180b89f25d4094012d5d2bd7967) | `` libspnav: 1.1 -> 1.2 ``                                                                   |