### PR TITLE
chore(flake/nixpkgs): `bdac72d3` -> `3108eaa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748186667,
-        "narHash": "sha256-UQubDNIQ/Z42R8tPCIpY+BOhlxO8t8ZojwC9o2FW3c8=",
+        "lastModified": 1748217807,
+        "narHash": "sha256-P3u2PXxMlo49PutQLnk2PhI/imC69hFl1yY4aT5Nax8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bdac72d387dca7f836f6ef1fe547755fb0e9df61",
+        "rev": "3108eaa516ae22c2360928589731a4f1581526ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`1fb0c251`](https://github.com/NixOS/nixpkgs/commit/1fb0c25139637ac56901ef481124f521d8b140ee) | `` flexget: 3.15.42 -> 3.16.1 ``                                                      |
| [`31c672e5`](https://github.com/NixOS/nixpkgs/commit/31c672e5885bdf5ce63021ac6ab727741d89556f) | `` python3Packages.contexttimer: unstable-2019-03-30 -> 2024-09-05 ``                 |
| [`c80cefcf`](https://github.com/NixOS/nixpkgs/commit/c80cefcff97c2d23784d9c1f975336770a73433d) | `` python3Packages.ptable:remove ``                                                   |
| [`a002df16`](https://github.com/NixOS/nixpkgs/commit/a002df160c43ed73d27e55c6c6ff599ee5d430ac) | `` python3Packages.softlayer: remove unused dependency ``                             |
| [`d2ed42f2`](https://github.com/NixOS/nixpkgs/commit/d2ed42f2dc684c3d2550b0157d4d2a42f732f486) | `` python3Packages.kivy-garden-modernmenu: remove ``                                  |
| [`88a78211`](https://github.com/NixOS/nixpkgs/commit/88a78211ca1497080c2c2597d6d04b589431cdb3) | `` python3Packages.kinparse: unstable-2019-12-18 -> 1.2.3 ``                          |
| [`884fc66c`](https://github.com/NixOS/nixpkgs/commit/884fc66c3839597badc64f3de6410cd3cb8d5a7f) | `` python3Packages.mutag: remove ``                                                   |
| [`42f7c724`](https://github.com/NixOS/nixpkgs/commit/42f7c724595c8b6350b1ed32551d971ce08b4425) | `` ollama: 0.7.0 -> 0.7.1 ``                                                          |
| [`95122514`](https://github.com/NixOS/nixpkgs/commit/951225149718c7596738df85268acc7ac955ce6d) | `` immich: 1.132.3 -> 1.133.1 ``                                                      |
| [`0a6bc066`](https://github.com/NixOS/nixpkgs/commit/0a6bc066dae9825b444922f6798a9a89aeb34d71) | `` gqrx: add darwin bundle ``                                                         |
| [`ee4fdf23`](https://github.com/NixOS/nixpkgs/commit/ee4fdf237f3e5e9b91d9cb3e13c0a1e6ba50af90) | `` python3Packages.docling-core: 2.30.1 -> 2.31.2 ``                                  |
| [`9dfeed8b`](https://github.com/NixOS/nixpkgs/commit/9dfeed8b42912c08d1a0a3411e538b9e180efe29) | `` python3Packages.eheimdigital: 1.1.0 -> 1.2.0 ``                                    |
| [`5aa1b5c8`](https://github.com/NixOS/nixpkgs/commit/5aa1b5c8291b5dc17e60a6fe8e87c681f622a02f) | `` nixos/readeck: improve systemd start target ``                                     |
| [`fab7c89a`](https://github.com/NixOS/nixpkgs/commit/fab7c89af495178c8eeb2715b7cc653efba31f99) | `` tcp-cutter: drop ``                                                                |
| [`70252a94`](https://github.com/NixOS/nixpkgs/commit/70252a94df09ad9c2facc5eddcf423254f250df3) | `` vscode-extensions.github.copilot-chat: 0.27.1 -> 0.27.2 ``                         |
| [`6c49f135`](https://github.com/NixOS/nixpkgs/commit/6c49f13575b9b639ab80629c6a1d3a862476a9bf) | `` superfile: 1.2.1 -> 1.3.1 ``                                                       |
| [`6558d752`](https://github.com/NixOS/nixpkgs/commit/6558d752ac5d9fca091352f4119f11481fff6eb8) | `` vscode-extensions.ms-toolsai.datawrangler: 1.21.1 -> 1.22.0 ``                     |
| [`5b64244f`](https://github.com/NixOS/nixpkgs/commit/5b64244f3fe95884b769ee9fa7ae6e74e7abff6c) | `` nixVersions.nix_2_29: init ``                                                      |
| [`51d32532`](https://github.com/NixOS/nixpkgs/commit/51d32532002aebc308388b3b9685babe9f5f595e) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.67.0 -> 1.69.0 ``           |
| [`4ac09413`](https://github.com/NixOS/nixpkgs/commit/4ac09413d6cf3eada6e6c0317bebdcccfe23ecc3) | `` vscode-extensions.danielgavin.ols: 0.1.35 -> 0.1.37 ``                             |
| [`2dc0fbc9`](https://github.com/NixOS/nixpkgs/commit/2dc0fbc979ec44ab128a92c9b57df3ae902f3e85) | `` vscode-extensions.github.copilot: 1.322.0 -> 1.323.0 ``                            |
| [`3371e0d6`](https://github.com/NixOS/nixpkgs/commit/3371e0d6df311e0c9d9c962b605800d3251a1bb8) | `` vscode-extensions.maximedenes.vscoq: 2.2.5 -> 2.2.6 ``                             |
| [`147c4599`](https://github.com/NixOS/nixpkgs/commit/147c4599f97da52f24e5b47282ef53991df1c8e6) | `` linux-it87: Update homepage to reflect new src repo ``                             |
| [`90b22d2b`](https://github.com/NixOS/nixpkgs/commit/90b22d2bae9fc268bfce1782c76f89b8f78772bb) | `` openvscode-server: remove bendlas as maintainer (#410867) ``                       |
| [`ed1b7f0e`](https://github.com/NixOS/nixpkgs/commit/ed1b7f0e7075c8835b96e300a29cb2671bd51749) | `` maintainers: add repparw ``                                                        |
| [`9a8b214c`](https://github.com/NixOS/nixpkgs/commit/9a8b214c68b1f658ebab39a8a52b0b2441323336) | `` task-master-ai: init at 0.15.0 ``                                                  |
| [`b942fb47`](https://github.com/NixOS/nixpkgs/commit/b942fb47dc604f25e4bb710a1072f30e675c973a) | `` workflows/eval: drop process job ``                                                |
| [`8a39ce4a`](https://github.com/NixOS/nixpkgs/commit/8a39ce4a48fab9b79be46e9ad28f410749f079d9) | `` workflows/eval: diff outpaths immediately ``                                       |
| [`a6b659b0`](https://github.com/NixOS/nixpkgs/commit/a6b659b08a58ed914c52a6042ad8b92ece8dea03) | `` workflows/eval: fetch target results in outpaths job ``                            |
| [`13f5aa30`](https://github.com/NixOS/nixpkgs/commit/13f5aa304ef68e02a35d0a26812217bb32d73be2) | `` workflows/eval: run trusted code in process step ``                                |
| [`b2579d36`](https://github.com/NixOS/nixpkgs/commit/b2579d36ffbf8691ed1e9fcdc001d5880277ae14) | `` workflows/eval: consistently avoid "result" in arguments ``                        |
| [`257e872d`](https://github.com/NixOS/nixpkgs/commit/257e872d5163976119c851e4cf25b2d61db792ad) | `` vscode-extensions.bradlc.vscode-tailwindcss: 0.14.16 -> 0.14.19 ``                 |
| [`b8ca5cd6`](https://github.com/NixOS/nixpkgs/commit/b8ca5cd6c6ed7c83287da62aad9c747e8026c146) | `` vscode-extensions.danielsanmedium.dscodegpt: 3.12.3 -> 3.12.38 ``                  |
| [`bed07713`](https://github.com/NixOS/nixpkgs/commit/bed077134ea733218a1fa2322fb3cf0b49f1e56f) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.27.2 -> 0.28.0 ``                 |
| [`d066b13b`](https://github.com/NixOS/nixpkgs/commit/d066b13b3b0e97c8de04bade9247b4b0e9b58856) | `` vscode-extensions.jnoortheen.nix-ide: 0.4.16 -> 0.4.18 ``                          |
| [`4531deee`](https://github.com/NixOS/nixpkgs/commit/4531deeed8529305f327ea6bf6c06fa417331586) | `` nixos/borgmatic: do not create source directories for empty databases (#410752) `` |
| [`3d0a5f81`](https://github.com/NixOS/nixpkgs/commit/3d0a5f81ecdbac8e7a762f9f08e9856e19b84160) | `` postman: add changelog ``                                                          |
| [`58979716`](https://github.com/NixOS/nixpkgs/commit/589797166a04ab3fe8760881b0e1ccf0dbf6d2c5) | `` postman: 1.44.0 -> 1.46.6 ``                                                       |
| [`853d9a1a`](https://github.com/NixOS/nixpkgs/commit/853d9a1ae47592dd224ac7bcf156ab89c7280a47) | `` python313Packages.cashaddress: remove problematic with lib usage ``                |
| [`20dcb038`](https://github.com/NixOS/nixpkgs/commit/20dcb0382de905a39b27b66b84315a4c232017a4) | `` python313Packages.cashaddress: fix version ``                                      |
| [`3641c822`](https://github.com/NixOS/nixpkgs/commit/3641c822a5eb029a74adf585a5f7133808b28cfe) | `` vscode-extensions.eugleo.magic-racket: 0.6.7 -> 0.7.0 ``                           |
| [`d328e68e`](https://github.com/NixOS/nixpkgs/commit/d328e68e81995a093df1e010b65e677d9794d4d7) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.12.1 -> 0.14.0 ``      |
| [`82901010`](https://github.com/NixOS/nixpkgs/commit/829010103137368f0431328435c9e17603e16837) | `` gpxsee-qt6: mark as unbroken on macOS ``                                           |
| [`2ee51807`](https://github.com/NixOS/nixpkgs/commit/2ee5180743ba4dd762a6440defd98bb1a2d2ea2c) | `` vscode-extensions.coder.coder-remote: 1.8.0 -> 1.9.0 ``                            |
| [`521560af`](https://github.com/NixOS/nixpkgs/commit/521560af3e737d8b5ca299d9d405fffdfc740e04) | `` python3Packages.pyfantom: drop ``                                                  |
| [`147794c3`](https://github.com/NixOS/nixpkgs/commit/147794c3b73dd04e310f374cd4d8920a79a97207) | `` python3Packages.langchain-community: disable flaky caching test ``                 |
| [`de1d5812`](https://github.com/NixOS/nixpkgs/commit/de1d581210a475747026974e600698a4f3a597cc) | `` python3Packages.hatch-vcs: apply pep517 lingo ``                                   |
| [`197d700c`](https://github.com/NixOS/nixpkgs/commit/197d700cfd530db38ab8c03ce824bcc9ec765062) | `` python3Packages.aiodocker: unstable-2022-01-20 -> 0.24.0 ``                        |
| [`fce95bac`](https://github.com/NixOS/nixpkgs/commit/fce95bacf133602590363b8afdf8ee395290e155) | `` retroarch-assets: 1.20.0-unstable-2025-03-21 -> 1.20.0-unstable-2025-05-23 ``      |
| [`c2f043aa`](https://github.com/NixOS/nixpkgs/commit/c2f043aafd2d07ec4e16414fff4b3a772d5554d7) | `` ruqola: init at 2.5.0 ``                                                           |
| [`810e02f0`](https://github.com/NixOS/nixpkgs/commit/810e02f034310ec0fe77b4625d2995ded5617c31) | `` gpxsee: 13.42 -> 13.43 ``                                                          |
| [`952db324`](https://github.com/NixOS/nixpkgs/commit/952db324ea7f9f50981f6d53b02c48647ad608d4) | `` gjay:drop ``                                                                       |
| [`e32f07b6`](https://github.com/NixOS/nixpkgs/commit/e32f07b6e1d63e3132e57a5d7eb84a8bcdcaf8b6) | `` cook-cli: 0.10.0 -> 0.12.1 ``                                                      |
| [`503a597b`](https://github.com/NixOS/nixpkgs/commit/503a597b744768d5cb54a15c0e6e966335b33b1f) | `` python3Packages.python-ecobee-api: 0.2.20 -> 0.3.0 ``                              |
| [`274bdab7`](https://github.com/NixOS/nixpkgs/commit/274bdab79f2e325d7500eb6a4e2f3930d73c2f35) | `` ida-free: use requireFile ``                                                       |
| [`00ca994b`](https://github.com/NixOS/nixpkgs/commit/00ca994bbb35f4bfa6a7c6ec63a1cc68434e76db) | `` ida-free: 9.0sp1 -> 9.1 ``                                                         |
| [`75bd0561`](https://github.com/NixOS/nixpkgs/commit/75bd05615bb88df2fd2afdd7fb7aa198cc657b9f) | `` xv: 6.0.2 -> 6.0.3 ``                                                              |
| [`daeba318`](https://github.com/NixOS/nixpkgs/commit/daeba3186a9b96aeb49998ec00736aed2abbe8b5) | `` python313Packages.smolagents: 1.13.0 -> 1.16.1 ``                                  |
| [`795fe553`](https://github.com/NixOS/nixpkgs/commit/795fe553bff52a19f50e164e38c1f7727dace43b) | `` python3Packages.mpris-server: 0.4.2 -> 0.9.6 ``                                    |
| [`e469cc78`](https://github.com/NixOS/nixpkgs/commit/e469cc78aefe3bbc7adeea7b0fae546a0085577d) | `` monophony: reformat meta ``                                                        |
| [`1e5d30a0`](https://github.com/NixOS/nixpkgs/commit/1e5d30a0baf37299906cc86aef16b3131a98af70) | `` monophony: 2.15.0 -> 3.3.3 ``                                                      |
| [`4291c6f2`](https://github.com/NixOS/nixpkgs/commit/4291c6f20f44d60ee2b6d571c33632d8986265a8) | `` cubeb: don't build shared libs on static platforms ``                              |
| [`0abfee46`](https://github.com/NixOS/nixpkgs/commit/0abfee4654187a82f2dba07b6cdf28b796988900) | `` cubeb: add pcsx2 and duckstation to tests ``                                       |
| [`a5b3ae44`](https://github.com/NixOS/nixpkgs/commit/a5b3ae44a55fe759a675c175c99449ddc28b36c5) | `` cubeb: add pkg-config validation ``                                                |
| [`81dca3bb`](https://github.com/NixOS/nixpkgs/commit/81dca3bb1e69fe9e6dc40514ce70bb741617a683) | `` cubeb: remove `with lib;` from meta ``                                             |
| [`a0841af3`](https://github.com/NixOS/nixpkgs/commit/a0841af35739757d9526a72659de4e88de3639ac) | `` treewide: remove cubeb.passthru.backendLibs ``                                     |
| [`709d5b4e`](https://github.com/NixOS/nixpkgs/commit/709d5b4e5c3554764aea4cb01dbb3f1f305e0974) | `` duckstation: use cubeb from nixpkgs ``                                             |
| [`9d9fc425`](https://github.com/NixOS/nixpkgs/commit/9d9fc4258d0816251396b747ed7be126c01d507a) | `` pcsx2: use cubeb from nixpkgs ``                                                   |
| [`ec588790`](https://github.com/NixOS/nixpkgs/commit/ec5887903e975835f1bc4f97926ee7e8a0caf84e) | `` rpcs3: use cubeb from nixpkgs ``                                                   |
| [`2fb8e742`](https://github.com/NixOS/nixpkgs/commit/2fb8e7424aecda596e2298c25cd2361df938bcdb) | `` cubeb: disable lazy loading ``                                                     |
| [`05404c27`](https://github.com/NixOS/nixpkgs/commit/05404c271c1859d871ab4fd5e17d337b3882604a) | `` cubeb: use cmakeBool for cmake flags ``                                            |
| [`027c0786`](https://github.com/NixOS/nixpkgs/commit/027c07866fd8574746392e9bb6b5f2b78f444573) | `` cubeb: split outputs ``                                                            |
| [`51151cb0`](https://github.com/NixOS/nixpkgs/commit/51151cb06a33f75e648894989d775027349ecda5) | `` cubeb: add pkg-config generation patch ``                                          |
| [`35e5c228`](https://github.com/NixOS/nixpkgs/commit/35e5c22876c54a09d1fb1b6e60d8333c4d60fc2a) | `` chickenPackages: fix meta.homepage ``                                              |
| [`47bcf810`](https://github.com/NixOS/nixpkgs/commit/47bcf810dfd76adf2145c68cedb544e858674e33) | `` tana: 1.0.30 -> 1.0.31 ``                                                          |
| [`b7988d22`](https://github.com/NixOS/nixpkgs/commit/b7988d22b788911c80c2af240f7f0fab34b71224) | `` treewide: substitute pname for strings (python3Packages.[s-z0-9_].*) ``            |
| [`0fc682e4`](https://github.com/NixOS/nixpkgs/commit/0fc682e4800021335ae1efa18a853c364fc1e8b6) | `` treewide: substitute pname for strings (python3Packages.[j-r].*) ``                |
| [`851756b3`](https://github.com/NixOS/nixpkgs/commit/851756b3afb512d0a201be9f5fa04c70d5fe8db7) | `` treewide: remove unreferenced patch files ``                                       |
| [`86e581ec`](https://github.com/NixOS/nixpkgs/commit/86e581ec89b428924132400a29ad945527da17c6) | `` python313Packages.mcpadapt: 0.1.5 -> 0.1.9 ``                                      |
| [`d3f53858`](https://github.com/NixOS/nixpkgs/commit/d3f538587bdcd76efd9c13640aa3d80b0111b59a) | `` tremor-language-server: 0.12.4 -> 0.13.0-rc.11 ``                                  |
| [`f604499d`](https://github.com/NixOS/nixpkgs/commit/f604499d5491b8a84f330eb36befd4805d417a78) | `` cubeb: unstable-2022-10-18 -> 0-unstable-2025-04-02 ``                             |
| [`5a749d80`](https://github.com/NixOS/nixpkgs/commit/5a749d80df533b7674ac8055be850e8d68a48373) | `` cubeb: add update script ``                                                        |
| [`a19f5554`](https://github.com/NixOS/nixpkgs/commit/a19f555474d399e0f0fe951adbfba3237a339803) | `` pixelorama: Unpin godot version ``                                                 |
| [`dd0483dd`](https://github.com/NixOS/nixpkgs/commit/dd0483dd6db54e60ba6798a469bf7c4125e18374) | `` alist: 3.44.0 -> 3.45.0 ``                                                         |
| [`729ef65d`](https://github.com/NixOS/nixpkgs/commit/729ef65de7009d2f9f5ad342ec8a93ce3f0d667f) | `` gensio: 2.8.14 -> 2.8.15 ``                                                        |
| [`ed9dc2ff`](https://github.com/NixOS/nixpkgs/commit/ed9dc2ff6815b4a5ddbb5488421c7c2b98583bdf) | `` jasp-desktop: 0.19.1 -> 0.19.3 ``                                                  |
| [`7a7887ba`](https://github.com/NixOS/nixpkgs/commit/7a7887ba54d1496c88aa675ab6e4c9b328b899b7) | `` quarkus: 3.22.2 -> 3.22.3 ``                                                       |
| [`e01f9b37`](https://github.com/NixOS/nixpkgs/commit/e01f9b378277fd79bfcf32f3eaddcac5ee87dd29) | `` sdl3: passthru sdl3-{image,ttf}, sdl2-compat and SDL_compat tests ``               |
| [`7c51c47e`](https://github.com/NixOS/nixpkgs/commit/7c51c47e645e8d24b970204dfcbe934454e30d06) | `` webdav: 5.7.5 -> 5.8.0 ``                                                          |
| [`f535dd19`](https://github.com/NixOS/nixpkgs/commit/f535dd19070d80a17cc22e3a6373d93a30edd4ca) | `` python313Packages.trimesh: 4.6.9 -> 4.6.10 ``                                      |
| [`0e11c494`](https://github.com/NixOS/nixpkgs/commit/0e11c494801f43cc09cb7c557cf7b2fcf8112e13) | `` paretosecurity: 0.2.17 -> 0.2.23 ``                                                |
| [`cf910d7c`](https://github.com/NixOS/nixpkgs/commit/cf910d7cabd27a3f403a483eabe42f1d66c823bd) | `` xtf: 0-unstable-2024-11-01 -> 0-unstable-2025-05-19 ``                             |
| [`80eaabf9`](https://github.com/NixOS/nixpkgs/commit/80eaabf92838903945860ed1cebdb278be8a61de) | `` lomiri.lomiri-system-settings-unwrapped: 1.3.0 -> 1.3.2 ``                         |
| [`98ad8444`](https://github.com/NixOS/nixpkgs/commit/98ad8444d1ff85e79d4fcf81a115336f52f4704d) | `` pixelorama: 1.1 -> 1.1.1 ``                                                        |
| [`edb9c458`](https://github.com/NixOS/nixpkgs/commit/edb9c458e89a9a039f7bc11b4c29d0fcab78465d) | `` libinput: 1.27.1 -> 1.28.1 ``                                                      |