### PR TITLE
chore(flake/nixpkgs): `3108eaa5` -> `ad331efc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748217807,
-        "narHash": "sha256-P3u2PXxMlo49PutQLnk2PhI/imC69hFl1yY4aT5Nax8=",
+        "lastModified": 1748248602,
+        "narHash": "sha256-LanRAm0IRpL36KpCKSknEwkBFvTLc9mDHKeAmfTrHwg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3108eaa516ae22c2360928589731a4f1581526ef",
+        "rev": "ad331efcaf680eb1c838cb339472399ea7b3cdab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`ad331efc`](https://github.com/NixOS/nixpkgs/commit/ad331efcaf680eb1c838cb339472399ea7b3cdab) | `` nixos/qemu-vm: useBootPartition -> useBIOSBoot ``                                 |
| [`c156a809`](https://github.com/NixOS/nixpkgs/commit/c156a809e37d80ac0cc5042f945bc2da0b86d289) | `` nixosTests.limine.bios: init ``                                                   |
| [`95355b4d`](https://github.com/NixOS/nixpkgs/commit/95355b4d94fd6019c03e0c800af412d0f25ef72c) | `` nixos/qemu-vm: add option for a separate boot partition on BIOS ``                |
| [`11ed9936`](https://github.com/NixOS/nixpkgs/commit/11ed9936cc426b85466d11809a336d8d08110a23) | `` nixos/make-disk-image: support partition layout `"legacy+boot"` ``                |
| [`9176f627`](https://github.com/NixOS/nixpkgs/commit/9176f62711f0dcb998c9e16eb4e8b16827a016e6) | `` pocl: 6.0-unstable-2025-01-02 -> 7.0 ``                                           |
| [`2c673b6e`](https://github.com/NixOS/nixpkgs/commit/2c673b6e6707d29037a386c4b579559d46b22347) | `` nixos/limine: fix boot entry not being created properly (#410935) ``              |
| [`a2f0a045`](https://github.com/NixOS/nixpkgs/commit/a2f0a0453dc9966f52e9304b036ac005ab79827d) | `` bashunit: 0.19.0 -> 0.19.1 ``                                                     |
| [`6f3db9f3`](https://github.com/NixOS/nixpkgs/commit/6f3db9f36094f5171db0d7247839eb3e4efc8ac0) | `` phpExtensions.excimer: 1.2.3 -> 1.2.5 ``                                          |
| [`4490c896`](https://github.com/NixOS/nixpkgs/commit/4490c896fb54c50b16d7d68b141e97bd24292e41) | `` phpPackages.phpstan: 2.1.15 -> 2.1.17 ``                                          |
| [`79277868`](https://github.com/NixOS/nixpkgs/commit/79277868d5741fc028adab59000ceb640d5aa639) | `` coredns: allow specifying position for externalPlugins (#360798) ``               |
| [`4e9ce9e5`](https://github.com/NixOS/nixpkgs/commit/4e9ce9e550fd2058833c65f87236a6abea88f377) | `` dbeaver-bin: 25.0.4 -> 25.0.5 ``                                                  |
| [`1f834fe6`](https://github.com/NixOS/nixpkgs/commit/1f834fe65205e501cf7f437d0c1a630f3fb11360) | `` gose: 0.10.5 -> 0.10.6 ``                                                         |
| [`57263c6c`](https://github.com/NixOS/nixpkgs/commit/57263c6cb43d530f86a986a4cc851aee8b84db1d) | `` jenkins: remove coconnor as maintainer ``                                         |
| [`c4173728`](https://github.com/NixOS/nixpkgs/commit/c4173728517b79fff068e900ac757152ceca5d1a) | `` libretro.citra: 0-unstable-2025-05-07 -> 0-unstable-2025-05-17 ``                 |
| [`06cb14c9`](https://github.com/NixOS/nixpkgs/commit/06cb14c949a38bc5be554a1603d01f0cfee14428) | `` android-udev-rules: 20250314 -> 20250525 ``                                       |
| [`c5a53489`](https://github.com/NixOS/nixpkgs/commit/c5a5348915a5b4750673eb273849992ef6dbb59c) | `` phpExtensions.mongodb: 2.0.0 -> 2.1.0 ``                                          |
| [`0271935b`](https://github.com/NixOS/nixpkgs/commit/0271935b80f3b94588e40dee1b7abc3c6cb6e18d) | `` immich-go: 0.26.2 -> 0.26.3 ``                                                    |
| [`f6c54fd1`](https://github.com/NixOS/nixpkgs/commit/f6c54fd18f80f512eb2773368faa813c2e570544) | `` guile-mqtt: 0.2.1 -> 1.0.0 ``                                                     |
| [`e721ada1`](https://github.com/NixOS/nixpkgs/commit/e721ada106ffa6000276ce8fd65b78ba1e2c33fc) | `` python312Packages.pytensor: 2.31.1 -> 2.31.2 ``                                   |
| [`507024d6`](https://github.com/NixOS/nixpkgs/commit/507024d6f9ce5993ed2e957661876a190e23c42f) | `` dart.sentry_flutter: fix ``                                                       |
| [`0736438e`](https://github.com/NixOS/nixpkgs/commit/0736438ef86dff359a2ad51ba1090f99ea2f5b55) | `` python3Packages.testing-postgresql: remove ``                                     |
| [`b0c322c6`](https://github.com/NixOS/nixpkgs/commit/b0c322c62ef0f1fca12fffcf22f5fd7ccbbf0328) | `` python3Packages.flask-silk: remove ``                                             |
| [`c7532483`](https://github.com/NixOS/nixpkgs/commit/c75324835f543f50a9ca202223679b64c8794be9) | `` librdf_redland: remove unused pcre dependency ``                                  |
| [`ade7dc60`](https://github.com/NixOS/nixpkgs/commit/ade7dc60ced6c802cd18ca2be32982f089c2391e) | `` libcs50: adopt and modernize ``                                                   |
| [`c8cfad40`](https://github.com/NixOS/nixpkgs/commit/c8cfad40015954b0a0df3ba83d7beb06ccd42b49) | `` vimPlugins.mini-keymap: init at 2025-05-20 ``                                     |
| [`deb0b290`](https://github.com/NixOS/nixpkgs/commit/deb0b2908f176a365a872164d8e36f286b5daf5b) | `` libcgroup: fix static build ``                                                    |
| [`125c99af`](https://github.com/NixOS/nixpkgs/commit/125c99afd43a53ed48736776898b2fc15f9812e6) | `` ddev: 1.24.5 -> 1.24.6 ``                                                         |
| [`3d990b36`](https://github.com/NixOS/nixpkgs/commit/3d990b364cf04e7c6b8b9bccfbda5b5cfbb1d22d) | `` rime-wanxiang: 6.7.9 -> 6.8.7 ``                                                  |
| [`def4373a`](https://github.com/NixOS/nixpkgs/commit/def4373ad704172e44b289c9c0c91486bed646b5) | `` beam26Packages.elixir-ls: 0.27.2 -> 0.28.1 ``                                     |
| [`906591c3`](https://github.com/NixOS/nixpkgs/commit/906591c38f5c5a4b1d602fd6ee3f0acfb065d283) | `` fancontrol-gui: init at 0.8 ``                                                    |
| [`9b5aea92`](https://github.com/NixOS/nixpkgs/commit/9b5aea92337798f33ec75420147fea707c642fa5) | `` haskell.packages.ghc865Binary: remove dontChecks ``                               |
| [`1c1bcd24`](https://github.com/NixOS/nixpkgs/commit/1c1bcd24d6d54254d50ea581f00c7ff44ace75b4) | `` vopono: 0.10.11 -> 0.10.12 ``                                                     |
| [`5cc6a948`](https://github.com/NixOS/nixpkgs/commit/5cc6a9481cb8b7acea9a66621e593b7ffcfd5257) | `` commandergenius: fix broken build due to renamed `_TTF_Font` struct in SDL_ttf `` |
| [`b722a789`](https://github.com/NixOS/nixpkgs/commit/b722a78968a33a9ac87f0f002d079a81fd351e75) | `` commandergenius: fix X11 includes ``                                              |
| [`4cf6ac7f`](https://github.com/NixOS/nixpkgs/commit/4cf6ac7f244cc38eb7d7a1bc8e147462d3982bc8) | `` ugarit: fix build on darwin ``                                                    |
| [`e32ab66a`](https://github.com/NixOS/nixpkgs/commit/e32ab66ae1bff15d6a3ed9f6814ad514dd62e0ed) | `` gcli: fix Darwin build ``                                                         |
| [`5fcf27a2`](https://github.com/NixOS/nixpkgs/commit/5fcf27a29bcb5fbe67e66870084f966de4edac68) | `` font-manager: 0.9.2 -> 0.9.4 ``                                                   |
| [`96551430`](https://github.com/NixOS/nixpkgs/commit/9655143028169f56b10f658ee58bdc20db6cda6e) | `` nixos/clevis: fix clevis in scripted initrd ``                                    |
| [`a52687d3`](https://github.com/NixOS/nixpkgs/commit/a52687d331e977d8c1f24c634b63cc09a6052aa5) | `` syft: 1.24.0 -> 1.26.1 ``                                                         |
| [`41a2f2ad`](https://github.com/NixOS/nixpkgs/commit/41a2f2ad56fc94f33fa30eb1206620e67ad88ad3) | `` matrix-appservice-discord: update meta.homepage ``                                |
| [`02b305e0`](https://github.com/NixOS/nixpkgs/commit/02b305e083ade13e61496b16872d7375392d8da0) | `` matrix-appservice-discord: fix build by pinning nodejs_20 ``                      |
| [`0fedafa2`](https://github.com/NixOS/nixpkgs/commit/0fedafa2a960b5c296eb4bdd08cd976aaf139207) | `` svg-text-to-path: init at 2.0.4 ``                                                |
| [`8b06db01`](https://github.com/NixOS/nixpkgs/commit/8b06db0131f34860685fefe8791f0ff28e360d7b) | `` wordpressPackages.plugins.civicrm: bump civicrm to 6.2.0 and fix install ``       |
| [`a37e5702`](https://github.com/NixOS/nixpkgs/commit/a37e5702f29d34d79a184301b7f538be0a6f53a3) | `` rusty-man: add defelo as maintainer ``                                            |
| [`83e09539`](https://github.com/NixOS/nixpkgs/commit/83e095396ead1045d283bfa8fab69caeb66f9e4d) | `` rusty-man: add updateScript ``                                                    |
| [`453d5d7f`](https://github.com/NixOS/nixpkgs/commit/453d5d7fcdd80888488202a41e4ab59288298224) | `` rusty-man: add versionCheckHook ``                                                |
| [`6c4a09dd`](https://github.com/NixOS/nixpkgs/commit/6c4a09dd8947d0c9180fc56b0ada91dd87bb2d5b) | `` rusty-man: remove `with lib;` ``                                                  |
| [`e954bf81`](https://github.com/NixOS/nixpkgs/commit/e954bf812adb7303eb12a170be5e80eef0789abd) | `` rusty-man: use hash in fetchFromSourcehut ``                                      |
| [`c84885bc`](https://github.com/NixOS/nixpkgs/commit/c84885bc051137319cf0e01579d5a188a7790792) | `` rusty-man: use finalAttrs pattern ``                                              |
| [`0475645f`](https://github.com/NixOS/nixpkgs/commit/0475645fb0539260552416a0fe6760fea47b8bda) | `` python3Packages.google-search-results: build from GitHub, modernize ``            |
| [`09ae6dfd`](https://github.com/NixOS/nixpkgs/commit/09ae6dfdd5994c694a8f40e7a199e9092abd9cf9) | `` gallery-dl: fix missing dependency for SOCKS support ``                           |
| [`3129e2b3`](https://github.com/NixOS/nixpkgs/commit/3129e2b389b59e9768084db1839b3655bad7e02f) | `` ps2patchelf: init at 1.0.0 ``                                                     |
| [`4ba4f6f3`](https://github.com/NixOS/nixpkgs/commit/4ba4f6f308d6dc9c45e7d3d371e28ff53cacf614) | `` git-annex-utils: Fix typo in deprecation throw ``                                 |
| [`bc6bdef1`](https://github.com/NixOS/nixpkgs/commit/bc6bdef11b3699d0d4eaf3a6d5c11990221cfbc1) | `` python3Packages.djangocms-alias: 2.0.2 -> 2.0.3 ``                                |
| [`974c3874`](https://github.com/NixOS/nixpkgs/commit/974c38747ba338e28515e81d24cb3829121aceb6) | `` llvmPackages_20.libc: fix by removing scudo ``                                    |
| [`d29618c8`](https://github.com/NixOS/nixpkgs/commit/d29618c87379d75ade9d62e7c111a1d2b76e5510) | `` tokei: add defelo as maintainer ``                                                |
| [`732bec3f`](https://github.com/NixOS/nixpkgs/commit/732bec3fe4cde6d1702227e029f6c143f3e11add) | `` tokei: add nix-update-script ``                                                   |
| [`ec4ef630`](https://github.com/NixOS/nixpkgs/commit/ec4ef6302c05ce4b5240fe657aade79f56c911a3) | `` tokei: add versionCheckHook ``                                                    |
| [`dee1607c`](https://github.com/NixOS/nixpkgs/commit/dee1607ccced1e05fe9c3121e1893832e4c09667) | `` tokei: add meta.changelog ``                                                      |
| [`09c5bb16`](https://github.com/NixOS/nixpkgs/commit/09c5bb16d8c34bfe3f84dbab7f02c04825adcbeb) | `` tokei: improve meta.description ``                                                |
| [`5d6cb0e4`](https://github.com/NixOS/nixpkgs/commit/5d6cb0e410b21605f48bdacd63976d3325b10830) | `` tokei: remove `with lib;` ``                                                      |
| [`a83df17a`](https://github.com/NixOS/nixpkgs/commit/a83df17a078ca97b2ca8d9785aab9418e278b450) | `` tokei: use tag and hash in fetchFromGitHub ``                                     |
| [`f7057320`](https://github.com/NixOS/nixpkgs/commit/f7057320c7d4825436d7248d5317fdf6763bb663) | `` tokei: use finalAttrs pattern ``                                                  |
| [`598138a1`](https://github.com/NixOS/nixpkgs/commit/598138a191db76f50a98635e68f7722b03fd2718) | `` tokei: don't use pname in src ``                                                  |
| [`ecc5126f`](https://github.com/NixOS/nixpkgs/commit/ecc5126fd0629d6a20c42af5fb0ba080894e0a51) | `` python3Packages.igloohome-api: 0.1.0 -> 0.1.1 ``                                  |
| [`5c1b7f19`](https://github.com/NixOS/nixpkgs/commit/5c1b7f1975bdd15289f3f15f43c7db587d9b08e2) | `` lapack: fix static build ``                                                       |
| [`ed13fb98`](https://github.com/NixOS/nixpkgs/commit/ed13fb9859183ae08e506dfaa564f7ab8a909a06) | `` kanboard: 1.2.44 -> 1.2.45 ``                                                     |
| [`d04bf863`](https://github.com/NixOS/nixpkgs/commit/d04bf863816f00125de04500f8c8a4c0a090f93b) | `` nixos.tests.pam-file-contents: fix build failure ``                               |
| [`c0099261`](https://github.com/NixOS/nixpkgs/commit/c0099261f9316d75150231b62289befda8911de5) | `` code-cursor: 0.49.6 -> 0.50.5 ``                                                  |
| [`7ba22724`](https://github.com/NixOS/nixpkgs/commit/7ba227244aaa7ddb238d764ce5b4ae5a630ef584) | `` ocrad: 0.27 -> 0.29 ``                                                            |
| [`3303249e`](https://github.com/NixOS/nixpkgs/commit/3303249ed2aa2131480737497abcee373e373216) | `` nixos/syncthing: fix cert/key permission error ``                                 |
| [`472eb192`](https://github.com/NixOS/nixpkgs/commit/472eb192b073f6e39bee661353cfc0251b10b9b6) | `` ath9k: fix build of old gmp by disabling compiler warnings ``                     |
| [`2e68a674`](https://github.com/NixOS/nixpkgs/commit/2e68a674bd80c8ac26013552dbb7abd2bab052c6) | `` nixos/bees: fix option example ``                                                 |
| [`5aa3674a`](https://github.com/NixOS/nixpkgs/commit/5aa3674a6194922562409cedebf4a7c6c173c89a) | `` code-cursor: use jq for update.sh ``                                              |
| [`293bb8f3`](https://github.com/NixOS/nixpkgs/commit/293bb8f3489419dde88799538cefac61fe2d150b) | `` code-cursor: add prince213 to maintainers ``                                      |
| [`ab5bbdad`](https://github.com/NixOS/nixpkgs/commit/ab5bbdad9ce7dea4e9495d156837dca97eca6c76) | `` hydra: 0-unstable-2025-04-16 -> 0-unstable-2025-04-23 ``                          |
| [`0ea65a68`](https://github.com/NixOS/nixpkgs/commit/0ea65a68a70906ea8ca0889942c7f19d45ccb43e) | `` python3Packages.django-celery-beat: 2.8.0 -> 2.8.1 ``                             |
| [`7970325e`](https://github.com/NixOS/nixpkgs/commit/7970325edbd3ec479b86907bce31f3af885858ba) | `` pidginPackages.pidgin-sipe: fix compilation error with libxml2 ``                 |
| [`466e7e1d`](https://github.com/NixOS/nixpkgs/commit/466e7e1da652ec53578eb9ebd6a2b109e9380581) | `` perlPackages.MaxMindDBWriter: unbreak on Darwin ``                                |
| [`451b6bc2`](https://github.com/NixOS/nixpkgs/commit/451b6bc25220e2e67b58f6f0d5adda25cf5d34d8) | `` perlPackages.SysVirt: unbreak on Darwin ``                                        |
| [`cde5ca50`](https://github.com/NixOS/nixpkgs/commit/cde5ca5093ae059737bb30be27b2635b94d904a8) | `` perlPackages.AlienLibGumbo: mark as broken on Linux instead of Darwin ``          |
| [`dd87890f`](https://github.com/NixOS/nixpkgs/commit/dd87890fa3aff2ec73214f84b3b8b2195e1c7042) | `` perlPackages.TextIconv: unbreak on Darwin ``                                      |
| [`46bd5876`](https://github.com/NixOS/nixpkgs/commit/46bd58768a12d2047ab4a93e3778fc09e2611d0b) | `` perlPackages.MaxMindDBReaderXS: unbreak on Darwin ``                              |
| [`34ce4c79`](https://github.com/NixOS/nixpkgs/commit/34ce4c790091ded1ab2b1c4597c4d796cd370360) | `` perlPackages.HTMLEscape: unbreak on Darwin ``                                     |
| [`f09a42bc`](https://github.com/NixOS/nixpkgs/commit/f09a42bc01ce3f3a22bb7d61db970ec923b1f87b) | `` perlPackages.DataMessagePack: unbreak on Darwin and fix description ``            |
| [`b860376d`](https://github.com/NixOS/nixpkgs/commit/b860376d83f0f5af5f3ccc7a81de0a03edcdae24) | `` perlPackages.DataUtil: unbreak on Darwin ``                                       |
| [`0598f4b0`](https://github.com/NixOS/nixpkgs/commit/0598f4b0bfa682fcdcaac1991f1e18042972408b) | `` perlPackages.FileLibMagic: unbreak on Darwin ``                                   |
| [`d35f21ec`](https://github.com/NixOS/nixpkgs/commit/d35f21ec470e7e75a71dc7a317c279dac806ed2e) | `` perlPackages.DBDsybase: unbreak on Darwin ``                                      |
| [`530c1394`](https://github.com/NixOS/nixpkgs/commit/530c13944813d0b1b7caed631257bf1b71b00ebd) | `` perlPackages.ApacheDB: unbreak on Darwin ``                                       |
| [`03ea79a2`](https://github.com/NixOS/nixpkgs/commit/03ea79a2b9ee3f7474d0762df96d96ab1580a9cb) | `` maintainers: add dashietm ``                                                      |
| [`bb4ba2ab`](https://github.com/NixOS/nixpkgs/commit/bb4ba2ab1c9135561db8b5db202ce0d288f100bf) | `` starship: add xonsh shell configuration ``                                        |
| [`5ea55be1`](https://github.com/NixOS/nixpkgs/commit/5ea55be1150850ea4cf48c3d0be6bad59399fa52) | `` nextcloud31Packages.apps.recognize: fix compilation ``                            |
| [`41f1eadb`](https://github.com/NixOS/nixpkgs/commit/41f1eadb7350d7fac73bcb71cf4cddacd416d28e) | `` nixos/zeronsd: fix acl permissions ``                                             |