### PR TITLE
Update Zed Editor packages

### DIFF
--- a/packages/zed-editor-bin/default.nix
+++ b/packages/zed-editor-bin/default.nix
@@ -18,7 +18,7 @@
   testers,
   lib,
 }: let
-  version = "0.187.8";
+  version = "0.187.9";
 
   # Map from Nix system → { url, sha256, type }
   assets = {
@@ -26,28 +26,28 @@
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-x86_64.tar.gz";
-      sha256 = "sha256-IRDESmig89bvoeeGyMB7H5PNU9utPZW4MRvfSwYgmBU=";
+      sha256 = "sha256-oGbulX86pj040FTsq9LI2I3iSCX6hgG4SyKVU0U89p8=";
       type = "tar.gz";
     };
     "aarch64-linux" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-aarch64.tar.gz";
-      sha256 = "sha256-OKX3ogM1gq4AZZ6dOaEbSrwQCTp7wIMAqIi9hBsD2xE=";
+      sha256 = "sha256-T7xbIS0L8kVx25M/beZBY/BLDcFiDiXn0LEOEhaP0a8=";
       type = "tar.gz";
     };
     "x86_64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-x86_64.dmg";
-      sha256 = "sha256-0MFvgsudun932mqCtWXJQWSN/ZgGnrhHHlmhmOi650s=";
+      sha256 = "sha256-PfRcswkYrmJwpljzQDiiBbZ5KIW26gT7GJuTZPPR5po=";
       type = "dmg";
     };
     "aarch64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-aarch64.dmg";
-      sha256 = "sha256-qib/5URxVLG2QA5CZgXk8Db1ouG9DAsBLxH3AP1/RW8=";
+      sha256 = "sha256-y+vUMYlOpuPPYZxvegyatlYVhaJtjsj8nlB/CXLBJpg=";
       type = "dmg";
     };
   };

--- a/packages/zed-editor-preview-bin/default.nix
+++ b/packages/zed-editor-preview-bin/default.nix
@@ -18,7 +18,7 @@
   testers,
   lib,
 }: let
-  version = "0.188.2-pre";
+  version = "0.188.3-pre";
 
   # Map from Nix system → { url, sha256, type }
   assets = {
@@ -26,28 +26,28 @@
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-x86_64.tar.gz";
-      sha256 = "sha256-epWZmjub1umHa6mOVI22LaaHhmrBeLMOicwvtJILVRk=";
+      sha256 = "sha256-RW/3InytgVP3SnvZJnItqEO8yjK2/ks8tLTuxjD77qM=";
       type = "tar.gz";
     };
     "aarch64-linux" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-aarch64.tar.gz";
-      sha256 = "sha256-wTltBFnifkeLHrw2W7zH53j80LtUFNOBj/m3064zM/0=";
+      sha256 = "sha256-TiSrbL0fRFZaQhbyU1vn3xLdQn7szh96JGwdcRGpxWo=";
       type = "tar.gz";
     };
     "x86_64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-x86_64.dmg";
-      sha256 = "sha256-ZKz48EztVnD0N0fLqs9Jivvfu+8EzHLvU+MQwyXtRz8=";
+      sha256 = "sha256-CpViq92FkAfqihn0P2eJQcF1K8fysr5HK6uQ3NBzM1Q=";
       type = "dmg";
     };
     "aarch64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-aarch64.dmg";
-      sha256 = "sha256-lFBV7kYYjIr8zsHrkGOSzoHGRwvjJUOtvdp1ooEgPsY=";
+      sha256 = "sha256-2YFLTX6ymdp+2jLhmlhpjrLDPSl8EQCHmX4pFPEIlMQ=";
       type = "dmg";
     };
   };

--- a/packages/zed-editor-preview/default.nix
+++ b/packages/zed-editor-preview/default.nix
@@ -98,7 +98,7 @@ assert withGLES -> stdenv.hostPlatform.isLinux; let
 in
   rustPlatform.buildRustPackage (finalAttrs: {
     pname = "zed-editor";
-    version = "0.188.2-pre";
+    version = "0.188.3-pre";
 
     outputs =
       ["out"]
@@ -110,7 +110,7 @@ in
       owner = "zed-industries";
       repo = "zed";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-j9g+MJeAYoaf8CYub2aEh7jyl68KEfCjRDjby7AqZSY=";
+      hash = "sha256-UG2eltPHy/o7p3Ht+dbS+ImSj6rsoa3f0eOxj23IjJM=";
     };
 
     patches = [
@@ -129,7 +129,7 @@ in
       '';
 
     useFetchCargoVendor = true;
-    cargoHash = "sha256-dMnwDBAPOO5l3J1LkBuk7luEuEEkOZbYHz81AwmNUEk=";
+    cargoHash = "sha256-fwX9wEbSDPqXz9j794K+S4mO/RYKuC+i7XVUwoAGL54=";
 
     nativeBuildInputs =
       [

--- a/packages/zed-editor/default.nix
+++ b/packages/zed-editor/default.nix
@@ -98,7 +98,7 @@ assert withGLES -> stdenv.hostPlatform.isLinux; let
 in
   rustPlatform.buildRustPackage (finalAttrs: {
     pname = "zed-editor";
-    version = "0.187.8";
+    version = "0.187.9";
 
     outputs =
       ["out"]
@@ -110,7 +110,7 @@ in
       owner = "zed-industries";
       repo = "zed";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-5bmE4QI3kmX/67O9jkEl2xstE3G+hsJ3H8gFkj146ao=";
+      hash = "sha256-BWn36z6EoyYRGtYZjWmTbu77M2wYNNBQ76u6MhKlkY4=";
     };
 
     patches = [
@@ -129,7 +129,7 @@ in
       '';
 
     useFetchCargoVendor = true;
-    cargoHash = "sha256-pgeO6dONFXFlS3eu5XeLScBX6K5e6bQfRnw+JnpWLQ4=";
+    cargoHash = "sha256-0EM3RaY9gClWsDGPrNo8JN80Wv5rKU84IyWkT4HZnJY=";
 
     nativeBuildInputs =
       [


### PR DESCRIPTION
This PR updates Zed Editor packages.

**Stable Channel:**
Updated from `0.187.8` to `0.187.9`.

Changes:
- Updated package versions in both `zed-editor` and `zed-editor-bin`
- Updated source hash in `zed-editor`
- Updated cargo hash in `zed-editor`
- Updated binary hashes in `zed-editor-bin`

Automatic Hash Updates (Stable):
Source hash for zed-editor: `sha256-BWn36z6EoyYRGtYZjWmTbu77M2wYNNBQ76u6MhKlkY4=`
Cargo hash for zed-editor: `sha256-0EM3RaY9gClWsDGPrNo8JN80Wv5rKU84IyWkT4HZnJY=`
Binary hashes for zed-editor-bin:
- x86_64-linux: `sha256-oGbulX86pj040FTsq9LI2I3iSCX6hgG4SyKVU0U89p8=`
- aarch64-linux: `sha256-T7xbIS0L8kVx25M/beZBY/BLDcFiDiXn0LEOEhaP0a8=`
- x86_64-darwin: `sha256-PfRcswkYrmJwpljzQDiiBbZ5KIW26gT7GJuTZPPR5po=`
- aarch64-darwin: `sha256-y+vUMYlOpuPPYZxvegyatlYVhaJtjsj8nlB/CXLBJpg=`

**Preview Channel:**
Updated from `0.188.2-pre` to `0.188.3-pre`.

Changes:
- Updated package versions in both `zed-editor-preview` and `zed-editor-preview-bin`
- Updated source hash in `zed-editor-preview`
- Updated cargo hash in `zed-editor-preview`
- Updated binary hashes in `zed-editor-preview-bin`

Automatic Hash Updates (Preview):
Source hash for zed-editor-preview: `sha256-UG2eltPHy/o7p3Ht+dbS+ImSj6rsoa3f0eOxj23IjJM=`
Cargo hash for zed-editor-preview: `sha256-fwX9wEbSDPqXz9j794K+S4mO/RYKuC+i7XVUwoAGL54=`
Binary hashes for zed-editor-preview-bin:
- x86_64-linux: `sha256-RW/3InytgVP3SnvZJnItqEO8yjK2/ks8tLTuxjD77qM=`
- aarch64-linux: `sha256-TiSrbL0fRFZaQhbyU1vn3xLdQn7szh96JGwdcRGpxWo=`
- x86_64-darwin: `sha256-CpViq92FkAfqihn0P2eJQcF1K8fysr5HK6uQ3NBzM1Q=`
- aarch64-darwin: `sha256-2YFLTX6ymdp+2jLhmlhpjrLDPSl8EQCHmX4pFPEIlMQ=`

**Flake:**
- Updated `flake.lock`

This update was created automatically by GitHub Actions.