### PR TITLE
chore(flake/nixpkgs): `ad331efc` -> `bdc995d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748248602,
-        "narHash": "sha256-LanRAm0IRpL36KpCKSknEwkBFvTLc9mDHKeAmfTrHwg=",
+        "lastModified": 1748281391,
+        "narHash": "sha256-fTll03tzUcgBrrMvD6O06TittBG2Ae6m3iW7aunxwPY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad331efcaf680eb1c838cb339472399ea7b3cdab",
+        "rev": "bdc995d3e97cec29eacc8fbe87e66edfea26b861",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`c5f66460`](https://github.com/NixOS/nixpkgs/commit/c5f66460cff0339b1b99ab562715a4e6f93df69d) | `` zsh: migrate to PCRE2 ``                                                           |
| [`34f59806`](https://github.com/NixOS/nixpkgs/commit/34f5980621e180ec910279c3d05cd9071df509c8) | `` nut: 2.8.2 -> 2.8.3 ``                                                             |
| [`b42493ff`](https://github.com/NixOS/nixpkgs/commit/b42493ffab2a667f45083c635089e088aaeac9c1) | `` python3Packages.python-swiftclient: 4.7.0 -> 4.8.0 (#410419) ``                    |
| [`ba3a4bdc`](https://github.com/NixOS/nixpkgs/commit/ba3a4bdcc5fc37875c55d9fc94fe0c7403f7d048) | `` python3Packages.ucsmsdk: 0.9.21 -> 0.9.22 ``                                       |
| [`e197bdd7`](https://github.com/NixOS/nixpkgs/commit/e197bdd7bc8c112171feb98f288f0095ba2d48bb) | `` mpv-subs-popout: 0.5.2 -> 0.5.3 ``                                                 |
| [`fc332121`](https://github.com/NixOS/nixpkgs/commit/fc332121eaa306701d6327416d8d918bf8fd36a0) | `` google-chrome: 136.0.7103.113 -> 137.0.7151.41 ``                                  |
| [`66fb435e`](https://github.com/NixOS/nixpkgs/commit/66fb435ef1999a1b4faf61cef9695f6bc587cff8) | `` lact: 0.7.3 -> 0.7.4 ``                                                            |
| [`6dfd5934`](https://github.com/NixOS/nixpkgs/commit/6dfd59344127611bfe344ba15d6ece6a09a230c9) | `` lact: switch to finalAttrs, add johnrtitor as maintainer ``                        |
| [`1fc7a63f`](https://github.com/NixOS/nixpkgs/commit/1fc7a63fd1b2731147d00fa4fd65a26cd4328048) | `` lact: add cything as maintainer ``                                                 |
| [`56e62a5d`](https://github.com/NixOS/nixpkgs/commit/56e62a5d4ef5e60e8f36ede03940db91c93f6d7c) | `` lact: add autoAddDriverRunpath to fix libnvidia-ml.so errors ``                    |
| [`8251941e`](https://github.com/NixOS/nixpkgs/commit/8251941e454169d61cc8aaf0ea9e8cbd4c3fa0a8) | `` lact: 0.7.1 -> 0.7.3 ``                                                            |
| [`fe930c61`](https://github.com/NixOS/nixpkgs/commit/fe930c6141f33596c7be8e8fd157af477e9ef72c) | `` lact: enable failing intel tests since they pass after the update ``               |
| [`4c855762`](https://github.com/NixOS/nixpkgs/commit/4c85576208f4fead84baab51cbaa93098743b662) | `` lact: 0.7.0 -> 0.7.1 ``                                                            |
| [`1036f7a4`](https://github.com/NixOS/nixpkgs/commit/1036f7a4c782c053673f86bbdbd4422e81176933) | `` lact: fix snapshot_everything test ``                                              |
| [`abd94976`](https://github.com/NixOS/nixpkgs/commit/abd94976c16794c2605bbd93713fb7684f8628fb) | `` lact: 0.6.0 -> 0.7.0 ``                                                            |
| [`eba9d202`](https://github.com/NixOS/nixpkgs/commit/eba9d2028ca08c67af1b5d7eb70d6feac91ee8cc) | `` coqPackages.ElmExtraction: 0.1.0 → 0.1.1 ``                                        |
| [`c9594b64`](https://github.com/NixOS/nixpkgs/commit/c9594b64fed8a7e8272cdbb772e324548ccf791a) | `` coqPackages.RustExtraction: 0.1.0 → 0.1.1 ``                                       |
| [`5e7fa3c3`](https://github.com/NixOS/nixpkgs/commit/5e7fa3c3d014a6986e0bee2279ee66ede05863b5) | `` wezterm: improve link to cargo auditable issue ``                                  |
| [`477c148a`](https://github.com/NixOS/nixpkgs/commit/477c148ae72498db74379358b6fb3c37c3bc9741) | `` python3Packages.meep: cleanup ``                                                   |
| [`718b9ee9`](https://github.com/NixOS/nixpkgs/commit/718b9ee9b3d1c3a696e39962c92febb03103fc28) | `` cobang: 1.6.2 -> 1.7.1 (#410799) ``                                                |
| [`2f8b917c`](https://github.com/NixOS/nixpkgs/commit/2f8b917c22be8a51a756793bd7944e880aef196b) | `` doc: mention adding maintainers must be done in a separate commit (#410292) ``     |
| [`7d8ab195`](https://github.com/NixOS/nixpkgs/commit/7d8ab1959d4c41cfce303b2bcdfb2a73e7fb0ab3) | `` Revert "stellarsolver: 2.6 -> 2.7" ``                                              |
| [`838dcf19`](https://github.com/NixOS/nixpkgs/commit/838dcf19592843529278158f95801b87142573a7) | `` joplin-desktop: revert addition of `--enable-wayland-ime` ``                       |
| [`82f7ecc2`](https://github.com/NixOS/nixpkgs/commit/82f7ecc21f585511071467f0279c7feb321f1c44) | `` python3Packages.python-openstackclient: 8.0.0 -> 8.1.0 ``                          |
| [`4c740d8a`](https://github.com/NixOS/nixpkgs/commit/4c740d8aa1c0712cf1e897690afd8e3b9d326714) | `` qdiskinfo: 0.3-unstable-2025-05-08 -> 0.3-unstable-2025-05-22 ``                   |
| [`47e0d78d`](https://github.com/NixOS/nixpkgs/commit/47e0d78dc7391cfc967c50d188e4dea570a9822d) | `` python312Packages.itables: init at 2.4.0 ``                                        |
| [`b2a6c1be`](https://github.com/NixOS/nixpkgs/commit/b2a6c1be50e07efcdb54f1ba13a4e58a15a51d88) | `` nvitop: 1.5.0 -> 1.5.1 ``                                                          |
| [`a9a498c4`](https://github.com/NixOS/nixpkgs/commit/a9a498c44cc14b01dd96925d0adc941589ad8651) | `` python312Packages.portion: 2.6.0 -> 2.6.1 ``                                       |
| [`c9c97fa9`](https://github.com/NixOS/nixpkgs/commit/c9c97fa99eb17760f3bc520a7779454cd55d4277) | `` niriswitcher: init at 0.5.2 ``                                                     |
| [`826fb664`](https://github.com/NixOS/nixpkgs/commit/826fb664c7953bbfbe3d0fb0a96d371765eab463) | `` terraform-providers.routeros: init at 1.85.0 ``                                    |
| [`4a00b3ce`](https://github.com/NixOS/nixpkgs/commit/4a00b3cebb933534eab7146e50d9493e0386d9ca) | `` pocketbase: 0.28.1 -> 0.28.2 ``                                                    |
| [`c882636a`](https://github.com/NixOS/nixpkgs/commit/c882636a6d95ca83f08851a066f8595b5177ddc5) | `` mirrord: 3.142.0 -> 3.142.2 ``                                                     |
| [`cc4689df`](https://github.com/NixOS/nixpkgs/commit/cc4689dfdc280217a08009f2648e17b1f3c61963) | `` wfview: 2.10 -> 2.11 ``                                                            |
| [`f782cd6e`](https://github.com/NixOS/nixpkgs/commit/f782cd6e3bf32dc9b0ff9c980a09308b2968ee0e) | `` nixos/mealie: fix test ``                                                          |
| [`1b4bae06`](https://github.com/NixOS/nixpkgs/commit/1b4bae067e5e3d17b904a12aab9d980197a30dec) | `` learn6502: init at 0.2.0 ``                                                        |
| [`188de1ee`](https://github.com/NixOS/nixpkgs/commit/188de1eee99173f4d7cadcb0c7efceea923f4d52) | `` radicale: 3.5.3 -> 3.5.4 ``                                                        |
| [`31395c76`](https://github.com/NixOS/nixpkgs/commit/31395c766ea3ba4d31f6abb0e63b9d1a10b2ed18) | `` nix: mark i686-linux cross builds as broken ``                                     |
| [`a4eed1fa`](https://github.com/NixOS/nixpkgs/commit/a4eed1fa7941b174a6111c61ef3d41bbdfbbfd53) | `` linux_6_15: init at 6.15 ``                                                        |
| [`68f4ce5c`](https://github.com/NixOS/nixpkgs/commit/68f4ce5c23b649b2ea01689fa27e33a88368c521) | `` kdePackages.polkit-kde-agent-1: add kirigami runtime dependency ``                 |
| [`231eb1df`](https://github.com/NixOS/nixpkgs/commit/231eb1df8fd3d2abcb60dcd1c8026c6c1dacfd52) | `` android-file-transfer: move to by-name ``                                          |
| [`507f43c6`](https://github.com/NixOS/nixpkgs/commit/507f43c6f0626d0f6af79e754fc32015a32694f7) | `` furnace: 0.6.8.1 -> 0.6.8.2 ``                                                     |
| [`36263688`](https://github.com/NixOS/nixpkgs/commit/36263688a41ad862ae6d65d972ed3b0e586c294a) | `` lifeograph: 3.0.1 -> 3.0.2 ``                                                      |
| [`5711b828`](https://github.com/NixOS/nixpkgs/commit/5711b828006dee94470e697de0f113aeae0da12b) | `` butterfly: 2.3.0 -> 2.3.1 ``                                                       |
| [`6ad885e4`](https://github.com/NixOS/nixpkgs/commit/6ad885e4804857c65d5ff86b9d48a6c5572f7de6) | `` python3Packages.oslo-utils: 8.2.0 -> 9.0.0 ``                                      |
| [`6068acb9`](https://github.com/NixOS/nixpkgs/commit/6068acb93a1add2c7ea775ebd1c2f379c4c54f9f) | `` vscode-extensions.redhat.vscode-xml: fix ``                                        |
| [`db549938`](https://github.com/NixOS/nixpkgs/commit/db5499388391e10d7bb8e7660e16847c72eb2c13) | `` uv-sort: 0.5.1 -> 0.6.0 ``                                                         |
| [`3b3c59b9`](https://github.com/NixOS/nixpkgs/commit/3b3c59b9843585f13ea4a3ca47fae8c9436ef1d7) | `` pageedit: move to pkgs/by-name ``                                                  |
| [`1645aa38`](https://github.com/NixOS/nixpkgs/commit/1645aa38339274d6fdd61ddab4bc05714d27f326) | `` lobster: 2025.1 -> 2025.2 ``                                                       |
| [`0591e43e`](https://github.com/NixOS/nixpkgs/commit/0591e43e63e7f7bc415486adf5f8489d50d495e8) | `` pageedit: 2.4.0 -> 2.5.0 ``                                                        |
| [`9cb51d74`](https://github.com/NixOS/nixpkgs/commit/9cb51d74b7a89f67a04d2325a338ad8122f549f4) | `` atac: 0.20.0 -> 0.20.1 ``                                                          |
| [`cbe9eb0b`](https://github.com/NixOS/nixpkgs/commit/cbe9eb0ba38fe7253d26d9b07200e73276e0ee1f) | `` asymptote: 3.03 -> 3.04 ``                                                         |
| [`481275c3`](https://github.com/NixOS/nixpkgs/commit/481275c3d7b464b11ef89161fcedf895aee5d96c) | `` glpng: 1.46 -> 1.47 ``                                                             |
| [`cd26d4b0`](https://github.com/NixOS/nixpkgs/commit/cd26d4b0bd9faeb402c5066e328c79a2cc03ca44) | `` heatseeker: 1.7.2 -> 1.7.3 ``                                                      |
| [`0d428634`](https://github.com/NixOS/nixpkgs/commit/0d4286346612e4f995893bf54d15fca169a5009a) | `` icewm: 3.7.4 -> 3.7.5 ``                                                           |
| [`c2a56cff`](https://github.com/NixOS/nixpkgs/commit/c2a56cffc3f6ff6d05206877c0e305f6aefdadd3) | `` python3Packages.ingredient-parser-nlp: 2.1.0 -> 2.1.1 ``                           |
| [`55e9440b`](https://github.com/NixOS/nixpkgs/commit/55e9440bc486393c6cc85f4511004ea3c9aaf367) | `` restinio: 0.7.4 -> 0.7.6 ``                                                        |
| [`6f7d7cf7`](https://github.com/NixOS/nixpkgs/commit/6f7d7cf76fb01215fca32ecd31bcd86d2250472e) | `` nixos/users-groups: allow changing default home directory ``                       |
| [`0302a2ac`](https://github.com/NixOS/nixpkgs/commit/0302a2ace6fe4bacc0437bf21bb946c8710ae5e9) | `` feedbackd-device-themes: init at 0.8.3 ``                                          |
| [`2e24917e`](https://github.com/NixOS/nixpkgs/commit/2e24917e8ff0b3cf3207547c96cf97b48c9a18d2) | `` feedbackd: 0.8.1 -> 0.8.2 ``                                                       |
| [`a554b067`](https://github.com/NixOS/nixpkgs/commit/a554b067fe405fbdf56bf71ddf64ce4d0e9c6c7c) | `` feedbackd: enable strictDeps ``                                                    |
| [`71d5f0f5`](https://github.com/NixOS/nixpkgs/commit/71d5f0f591c7ec68d2ca476aee4f57039cf51fd6) | `` nixos/tests/prowlarr: add subtest for dataDir migration ``                         |
| [`97557de1`](https://github.com/NixOS/nixpkgs/commit/97557de1e29d0ee88e15b1536eaf59d6e212b0d6) | `` nixos/prowlarr: use DynamicUser again, configure bind mount for custom dataDirs `` |
| [`bc933834`](https://github.com/NixOS/nixpkgs/commit/bc933834137a86068fdf6e5e2d3bddc72479d33b) | `` spacer: 0.3.8 -> 0.3.9 ``                                                          |
| [`c9a4d7be`](https://github.com/NixOS/nixpkgs/commit/c9a4d7bea86441a63c5f77fdf952ab5b83bb3f63) | `` claude-code: 1.0.2 -> 1.0.3 ``                                                     |
| [`f9692698`](https://github.com/NixOS/nixpkgs/commit/f969269821b57cd02f2a8ca3f3e4c30c92a371f4) | `` maintainers: add bokicoder ``                                                      |
| [`61cf94db`](https://github.com/NixOS/nixpkgs/commit/61cf94db58cb3c0cf463d7dd8144fd6c1af08100) | `` repomix: 0.3.5 -> 0.3.6 ``                                                         |
| [`02b51726`](https://github.com/NixOS/nixpkgs/commit/02b517263f683cbc0f606017559deccc5fdcba73) | `` imager: fix numpy header detection ``                                              |
| [`be09c484`](https://github.com/NixOS/nixpkgs/commit/be09c484fa822dc70a5e088fdd01889195d957da) | `` strawberry: 1.2.10 -> 1.2.11 ``                                                    |
| [`0fd21089`](https://github.com/NixOS/nixpkgs/commit/0fd21089d8d83fc0e48578909cb725f79e1f99fa) | `` helio-workstation: 3.15 -> 3.16 ``                                                 |
| [`bc62ff09`](https://github.com/NixOS/nixpkgs/commit/bc62ff092659a1ff50291fa89e201d4512683c16) | `` stellarsolver: 2.6 -> 2.7 ``                                                       |
| [`91299819`](https://github.com/NixOS/nixpkgs/commit/9129981942e2135e5a88d5359aaed740a3d7a9ba) | `` sish: 2.18.0 -> 2.19.0 ``                                                          |
| [`6c9967ce`](https://github.com/NixOS/nixpkgs/commit/6c9967ce724adc0b55fcd180bb3c665a06985902) | `` paperless-ngx: 2.16.1 -> 2.16.2 ``                                                 |
| [`d88de363`](https://github.com/NixOS/nixpkgs/commit/d88de3637f09858d435f713459ffb95d18d1bee1) | `` radicle-{explorer,httpd}: 0.18.1 -> 0.18.2 ``                                      |
| [`0695b7b7`](https://github.com/NixOS/nixpkgs/commit/0695b7b7044b8f94ab2666343363ec4b58edd2bf) | `` timewarrior: Install fish and zsh completions ``                                   |
| [`5b986cee`](https://github.com/NixOS/nixpkgs/commit/5b986ceec47abef4a197b741dfb629df9f0872cb) | `` talosctl: 1.10.1 -> 1.10.2 ``                                                      |
| [`cd6a92d0`](https://github.com/NixOS/nixpkgs/commit/cd6a92d0f09e0f7964e95722f2e4c2dcfd101aa8) | `` rstudio{,-server}: 2024.12.1+563 -> 2025.05.0+496 ``                               |
| [`64fd6777`](https://github.com/NixOS/nixpkgs/commit/64fd6777559f309d11dda634a4219d1c1d6ff744) | `` neothesia: install default soundfont ``                                            |
| [`aef123f9`](https://github.com/NixOS/nixpkgs/commit/aef123f9d7dace579b642fc2b6d20ef477574395) | `` nixos/doc/rl-2505: ensure consistency between module option links ``               |
| [`e02add77`](https://github.com/NixOS/nixpkgs/commit/e02add77063b34d13cafd23ecbd58f0f86d81631) | `` hasura-cli: 2.3.1 -> 2.48.1 ``                                                     |
| [`e02ad17d`](https://github.com/NixOS/nixpkgs/commit/e02ad17dbc8c09356df113d94b130fd573d30b57) | `` reth: 1.3.12 -> 1.4.3 ``                                                           |
| [`d5d323a9`](https://github.com/NixOS/nixpkgs/commit/d5d323a907b0ff04ec0b78fbf35d96ea270cafc5) | `` emergencyMode, emergencyAccess: cross reference options in docs. ``                |
| [`46a8e585`](https://github.com/NixOS/nixpkgs/commit/46a8e585bd1ba4ea1532ab847a98992f99bb666a) | `` firefox-bin: don't break code signing on macOS ``                                  |
| [`ceabb205`](https://github.com/NixOS/nixpkgs/commit/ceabb2059d7247dfc160ba0ef1d073ecced3df3a) | `` chroot-realpath: Add error context ``                                              |
| [`d870438b`](https://github.com/NixOS/nixpkgs/commit/d870438bcab82f0ec8cc619c7cdf4bf6a17ab563) | `` wezterm: 0-unstable-2025-02-23 -> 0-unstable-2025-05-18 ``                         |
| [`be3ef9cb`](https://github.com/NixOS/nixpkgs/commit/be3ef9cbba2bbb8e018088817ed80d9440540a30) | `` defuddle-cli: init at 0.6.4 ``                                                     |
| [`3d7c2efe`](https://github.com/NixOS/nixpkgs/commit/3d7c2efe8f2589fc841a17c3f27cd15bb9c4f256) | `` maa-assistant-arknights: 5.16.4 -> 5.16.9 ``                                       |
| [`9b0f238b`](https://github.com/NixOS/nixpkgs/commit/9b0f238bd4e25b17f3e9c994616ca8f540720f7e) | `` termius: 9.19.4 -> 9.20.0 ``                                                       |
| [`ef45eca8`](https://github.com/NixOS/nixpkgs/commit/ef45eca82d8baa2833a3ded45eef7f856052dda6) | `` proton-pass: 1.31.2 -> 1.31.4 ``                                                   |
| [`959c8e93`](https://github.com/NixOS/nixpkgs/commit/959c8e931134c3f986474045c24b05f09b1d770e) | `` nixos/anubis: Apply some more hardening settings ``                                |
| [`4907750a`](https://github.com/NixOS/nixpkgs/commit/4907750a173268bf52f55bd16f3669bf2edeac30) | `` mill: 0.12.11 -> 0.12.14 ``                                                        |
| [`2fc65403`](https://github.com/NixOS/nixpkgs/commit/2fc65403f506d06077f28d4bdc4861f18b311431) | `` smartsynchronize: 4.6.1 -> 4.6.2 ``                                                |
| [`77c45ea1`](https://github.com/NixOS/nixpkgs/commit/77c45ea139cdc330f1dd651beee948060d33fcea) | `` oha: Use system jemalloc ``                                                        |
| [`8be67b24`](https://github.com/NixOS/nixpkgs/commit/8be67b24cf95ed94632d302dd036d75aaadeacbc) | `` home-assistant-custom-components.oref_alert: init at 2.20.1 ``                     |
| [`accf03b1`](https://github.com/NixOS/nixpkgs/commit/accf03b12f5d1fbbae8a7c6130567d4037774555) | `` varia: 2025.4.22 -> 2025.5.14 ``                                                   |
| [`92057c24`](https://github.com/NixOS/nixpkgs/commit/92057c24448afcec363da90dd58162bd0fad72a0) | `` glitchtip: 4.2.10 -> 5.0.1 ``                                                      |
| [`29f7024e`](https://github.com/NixOS/nixpkgs/commit/29f7024e91bf509e7f21a5eb1c9b300fa31b1358) | `` python313Packages.django-postgres-partition: init at 0.1.1 ``                      |
| [`9fcf26cd`](https://github.com/NixOS/nixpkgs/commit/9fcf26cd2d72a1e4ec98b26b10cd3a4672daf1cc) | `` python313Packages.django-ninja-cursor-pagination: init at 0.1.0 ``                 |
| [`abb968bc`](https://github.com/NixOS/nixpkgs/commit/abb968bc72aa6c29b37e6e1c65960539671c65c0) | `` rotonda: 0.4.0 -> 0.4.1 ``                                                         |
| [`795e3176`](https://github.com/NixOS/nixpkgs/commit/795e317647b0d07ee24e292072d83ac5aea1c964) | `` spotify/darwin: 1.2.40.599.g606b7f29 -> 1.2.64.408 ``                              |
| [`afa43e13`](https://github.com/NixOS/nixpkgs/commit/afa43e1383d4d604ed3575bf95b3905354a9a51b) | `` spotify/linux: 1.2.59.514.g834e17d4 -> 1.2.60.564.gcc6305cb ``                     |
| [`ee0fd4e0`](https://github.com/NixOS/nixpkgs/commit/ee0fd4e0aee172d4bc98f4aa7b56ba46c4e9005f) | `` spotify/linux: allow overriding `version` and `rev` ``                             |
| [`cbeeccdd`](https://github.com/NixOS/nixpkgs/commit/cbeeccddb04ca6c68b462bf0d543f45ad3d822f5) | `` spotify: add macOS support to update script ``                                     |
| [`d1578f3c`](https://github.com/NixOS/nixpkgs/commit/d1578f3c7e7480195903f533322e49d3fc77c22a) | `` spotify: set `passthru.updateScript` ``                                            |
| [`6d626616`](https://github.com/NixOS/nixpkgs/commit/6d62661638fdff6def5625ba016f13ec3c1d0bdb) | `` graphite-cli: 1.6.1 -> 1.6.2 ``                                                    |
| [`3bde254e`](https://github.com/NixOS/nixpkgs/commit/3bde254e590f1614b0fb59156ecbdd70ea78940f) | `` python3Packages.ansible-compat: 25.1.5 -> 25.5.0 ``                                |
| [`2e13b6d7`](https://github.com/NixOS/nixpkgs/commit/2e13b6d7763626bf532da62d0339fb1c5ff40891) | `` nb: 7.18.1 -> 7.19.1 ``                                                            |
| [`a8993f69`](https://github.com/NixOS/nixpkgs/commit/a8993f698536a30074d7fca7aa355aaf1ee19a67) | `` nanoboyadvance: 1.8.1 -> 1.8.2 ``                                                  |
| [`f9e9c67e`](https://github.com/NixOS/nixpkgs/commit/f9e9c67e53ba2fea76d1e7965e03ca2f78a26db4) | `` android-file-transfer: use qt6 ``                                                  |
| [`ab0cc8e5`](https://github.com/NixOS/nixpkgs/commit/ab0cc8e55f15595141cb8d08e135866237a283f7) | `` added l0r3v to maintainers ``                                                      |
| [`dd3f33fc`](https://github.com/NixOS/nixpkgs/commit/dd3f33fca0cb0b1632422e71b189bf222955266d) | `` whois: 5.6.0 -> 5.6.1 ``                                                           |
| [`93899a09`](https://github.com/NixOS/nixpkgs/commit/93899a09a7c09ac989dcbdce2e2fdecab79b973b) | `` python3Packages.langgraph-sdk: 0.1.66 -> 0.1.69 ``                                 |
| [`c84ab5f0`](https://github.com/NixOS/nixpkgs/commit/c84ab5f0f13a78593ec5819ae569d5ea56ab26a5) | `` cider-2: 2.6.1 -> 3.0.2 ``                                                         |
| [`aed65d7e`](https://github.com/NixOS/nixpkgs/commit/aed65d7e52ddf89e195c674cf1947a648f1e1133) | `` python3Packages.langchain-anthropic: 0.3.12 -> 0.3.13 ``                           |
| [`6f6ba119`](https://github.com/NixOS/nixpkgs/commit/6f6ba119b647340936a57c88c6a3975cfe0db227) | `` nmap: 7.96 -> 7.97 ``                                                              |
| [`84e02649`](https://github.com/NixOS/nixpkgs/commit/84e0264997e77ddb699b4a0ba8d49da92af60785) | `` home-assistant-custom-components.home_connect_alt: init at 1.2.1 ``                |
| [`06edb5eb`](https://github.com/NixOS/nixpkgs/commit/06edb5eb15644ed368daad5adfe380ac10fe17b3) | `` python3Packages.home-connect-async: init at 0.8.2 ``                               |
| [`241245c7`](https://github.com/NixOS/nixpkgs/commit/241245c764d5e7a6a085209db95ca42fa805f7f0) | `` python3Packages.aiohttp-sse-client: init at 0.2.1 ``                               |
| [`1d0a5c25`](https://github.com/NixOS/nixpkgs/commit/1d0a5c25fcc440425af096e0996e04866d9c3f78) | `` python3Packages.oauth2-client: init at 1.4.2 ``                                    |
| [`1d277600`](https://github.com/NixOS/nixpkgs/commit/1d2776003776234c7eb05a6eaa0ad73261b15af0) | `` mcat: init at 0.2.8 ``                                                             |
| [`306fdc57`](https://github.com/NixOS/nixpkgs/commit/306fdc573b6f08296fb83695b704cbbbf69b3da2) | `` android-file-transfer: 4.4 -> 4.5 ``                                               |
| [`3af1f87c`](https://github.com/NixOS/nixpkgs/commit/3af1f87c5ddf8d7d98067d16904b7a5c4e2c4622) | `` traefik: 3.3.6 -> 3.4.0 ``                                                         |
| [`db170a9c`](https://github.com/NixOS/nixpkgs/commit/db170a9c623dc81a7fe38c10ad2f23c18f0e74bf) | `` clazy: 1.13 -> 1.14 ``                                                             |
| [`13130a25`](https://github.com/NixOS/nixpkgs/commit/13130a258b16b9f10e33a2c97c3ac2ad73373ca0) | `` python3Packages.phonopy: 2.37.0 -> 2.38.2 ``                                       |
| [`2035aa58`](https://github.com/NixOS/nixpkgs/commit/2035aa58e88b15868ec5682ea0841ca24bcf9d32) | `` oneDNN: 3.7.3 -> 3.8 ``                                                            |
| [`5314fe94`](https://github.com/NixOS/nixpkgs/commit/5314fe947d135936ae813fd582248f933fee85d0) | `` taldir: init at 1.0.5 ``                                                           |
| [`2b946599`](https://github.com/NixOS/nixpkgs/commit/2b946599989e011952ab41b84b3076f16ba564ba) | `` openssh: Add locale archive patch note ``                                          |
| [`0d3967d6`](https://github.com/NixOS/nixpkgs/commit/0d3967d62cfc59a702cf26f30e20bc831e569e28) | `` openssh: Add ssh-keysign patch note ``                                             |
| [`4d4f431f`](https://github.com/NixOS/nixpkgs/commit/4d4f431ff79e70ffd9450e0b7f24a9e6aa587d9e) | `` nixos/nh: allow flake uris ``                                                      |
| [`56a66ce9`](https://github.com/NixOS/nixpkgs/commit/56a66ce90a060146edd6117f9b0eecc885827dab) | `` cantata: 2.5.0 -> 3.3.1 ``                                                         |
| [`98c23a61`](https://github.com/NixOS/nixpkgs/commit/98c23a61c3d0cce6bdfd12c76a5d72f4983a3a6d) | `` nixos/networkmanager: add an `enableDefaultPlugins` option ``                      |