### PR TITLE
chore(flake/nixpkgs): `bdc995d3` -> `e0042ded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748281391,
-        "narHash": "sha256-fTll03tzUcgBrrMvD6O06TittBG2Ae6m3iW7aunxwPY=",
+        "lastModified": 1748344075,
+        "narHash": "sha256-PsZAY3H0e/PBoDVn4fLwGEmeSwESj7SZPZ6CMfgbWFU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bdc995d3e97cec29eacc8fbe87e66edfea26b861",
+        "rev": "e0042dedfbc9134ef973f64e5c7f56a38cc5cc97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`7df8c92c`](https://github.com/NixOS/nixpkgs/commit/7df8c92cbc7d5fb8310b22205203d7fbbda46e81) | `` parca-agent: 0.38.2 -> 0.39.0 ``                                        |
| [`b937812e`](https://github.com/NixOS/nixpkgs/commit/b937812e01001dc4d458d852e23b503de28178e9) | `` parca-agent: add `nix-update-script` ``                                 |
| [`46aea2e7`](https://github.com/NixOS/nixpkgs/commit/46aea2e76f85682940cad52fa2af06ae6f5df9cc) | `` Revert "mlt: 7.30.0 -> 7.32.0" ``                                       |
| [`cbbe1798`](https://github.com/NixOS/nixpkgs/commit/cbbe1798f47986427ba1055e8c81f237803bb8e1) | `` vscode-extensions.betterthantomorrow.calva: 2.0.512 -> 2.0.516 ``       |
| [`c33daf29`](https://github.com/NixOS/nixpkgs/commit/c33daf2918646310f722187afe29a41cec3a8b72) | `` justbuild: 1.5.1 -> 1.5.2 ``                                            |
| [`59b5226d`](https://github.com/NixOS/nixpkgs/commit/59b5226dd3120d21cfb381fb53aed683035a4dbf) | `` python3Packages.primecountpy: 0.1.0 -> 0.1.1 ``                         |
| [`397e3986`](https://github.com/NixOS/nixpkgs/commit/397e3986bfb48eb1168ff2352e72a8800da3f388) | `` msr-tools: 1.3 -> 1.3-unstable-2022-08-05 ``                            |
| [`a4a69667`](https://github.com/NixOS/nixpkgs/commit/a4a69667db06da9aaddbe95136cf9b4b13a76771) | `` rerun: 0.23.2 -> 0.23.3 ``                                              |
| [`53b62026`](https://github.com/NixOS/nixpkgs/commit/53b62026457bb90b671adbd7311aa1f87473213f) | `` gimp3: add to release-cuda ``                                           |
| [`139df70d`](https://github.com/NixOS/nixpkgs/commit/139df70d8d052d82039ac41faa8c87a0b64ee143) | `` zoxide: 0.9.7 -> 0.9.8 ``                                               |
| [`be243e8c`](https://github.com/NixOS/nixpkgs/commit/be243e8cca0af54b926f83ebeea6b4fce0064b38) | `` watcher: 0.13.5 -> 0.13.6 ``                                            |
| [`8c3d4830`](https://github.com/NixOS/nixpkgs/commit/8c3d48300dfb32be97ce161219e8a615170135ad) | `` snips-sh: 0.4.2 -> 0.5.0 ``                                             |
| [`332e91d5`](https://github.com/NixOS/nixpkgs/commit/332e91d588a2214bd1018197f52fd00360018e87) | `` prettyping: 1.0.1 -> 1.1.0 ``                                           |
| [`72c93a1a`](https://github.com/NixOS/nixpkgs/commit/72c93a1ab0ce962378caece59a6a7b63cbc6a00a) | `` netbird-ui: 0.44.0 -> 0.45.1 ``                                         |
| [`71ac797e`](https://github.com/NixOS/nixpkgs/commit/71ac797e3ee471078ef609ac738dad8b83119016) | `` libretro.scummvm: 0-unstable-2025-04-05 -> 0-unstable-2025-05-23 ``     |
| [`a2049762`](https://github.com/NixOS/nixpkgs/commit/a2049762f2c0fea4067a019178d030b3113b3d1b) | `` geany-with-vte: add note about inheriting meta ``                       |
| [`571c5c02`](https://github.com/NixOS/nixpkgs/commit/571c5c020b721496d6a43c647578b07eb1b8d43c) | `` vscode-extensions.sonarsource.sonarlint-vscode: 4.22.0 -> 4.23.0 ``     |
| [`8d782353`](https://github.com/NixOS/nixpkgs/commit/8d782353b0693306533d616256767354bb365351) | `` root: 6.34.08 -> 6.36.00 (#390706) ``                                   |
| [`9aeaf31f`](https://github.com/NixOS/nixpkgs/commit/9aeaf31fce3c39059bb1115f2414fd87a225859b) | `` mitra: 4.2.1 -> 4.3.1 ``                                                |
| [`62b34d8a`](https://github.com/NixOS/nixpkgs/commit/62b34d8ae10963109ed1f1d3154fd71a323a2d00) | `` particle-cli: 3.35.10 -> 3.35.11 ``                                     |
| [`3db849b8`](https://github.com/NixOS/nixpkgs/commit/3db849b8f9c56796ee9e06bdb7f8291c62d84a26) | `` stunnel: 5.74 -> 5.75 ``                                                |
| [`050ed018`](https://github.com/NixOS/nixpkgs/commit/050ed018742159cba6da6d7414701240917ec5ca) | `` ruqola: 2.5.0 -> 2.5.1 ``                                               |
| [`b371fc9c`](https://github.com/NixOS/nixpkgs/commit/b371fc9cef3f330e015b74c944b3d81e0ff519be) | `` forecast: 0-unstable-2025-05-15 -> 0-unstable-2025-05-25 ``             |
| [`9eb380a4`](https://github.com/NixOS/nixpkgs/commit/9eb380a4cc4793f7481574c1f756e236856c1d49) | `` circt: 1.118.0 -> 1.119.0 ``                                            |
| [`cc31b635`](https://github.com/NixOS/nixpkgs/commit/cc31b635a99fed0baf717b4e32a58c019af9ec71) | `` firefox-bin-unwrapped: 138.0.4 -> 139.0 ``                              |
| [`a91995a5`](https://github.com/NixOS/nixpkgs/commit/a91995a5a1f3da13d638a2a3454a6c79f90b5a14) | `` firefox-esr-128-unwrapped: 128.10.1esr -> 128.11.0esr ``                |
| [`83d02af8`](https://github.com/NixOS/nixpkgs/commit/83d02af8b35fd69b8bc795a6aea942b1c8ce7015) | `` firefox-unwrapped: 138.0.4 -> 139.0 ``                                  |
| [`3587619b`](https://github.com/NixOS/nixpkgs/commit/3587619b1a188ba20cb94a71b27b2f9776c44128) | `` nix-eval-jobs: 2.28.1 -> 2.29.0 ``                                      |
| [`9f8d45af`](https://github.com/NixOS/nixpkgs/commit/9f8d45af8c33a23e33c04772afaf0d23bb39fe96) | `` perses: init at 0.51.0-rc.0 ``                                          |
| [`e98656cb`](https://github.com/NixOS/nixpkgs/commit/e98656cb48de4ce1adf4b58c0dda963765faea62) | `` ty: 0.0.1-alpha.6 -> 0.0.1-alpha.7 ``                                   |
| [`1f3007ca`](https://github.com/NixOS/nixpkgs/commit/1f3007cac9d760abe706b268d9809ff4ce345d27) | `` supabase-cli: 2.23.1 -> 2.23.7 ``                                       |
| [`68357544`](https://github.com/NixOS/nixpkgs/commit/68357544ec7f310dbfaa8bb822013bf980d95011) | `` python313Packages.dissect-volume: 3.13 -> 3.15 ``                       |
| [`04024abd`](https://github.com/NixOS/nixpkgs/commit/04024abdda114d6c731b3eea245ef1f0c018dd4a) | `` python313Packages.dissect-jffs: 1.4 -> 1.5 ``                           |
| [`8dbb549c`](https://github.com/NixOS/nixpkgs/commit/8dbb549c8b915534f25b74df5ce77390a70e06b9) | `` python313Packages.dissect-ole: 3.10 -> 3.11 ``                          |
| [`a2541230`](https://github.com/NixOS/nixpkgs/commit/a25412306539e7ecefeb0dc81ca9c6e07b87636a) | `` flutter: optimize evaluation of appBuildDeps ``                         |
| [`94817274`](https://github.com/NixOS/nixpkgs/commit/94817274d2208ef5356b2dc450c22fdf195f8501) | `` lib.fileset.difference: fix type docs ``                                |
| [`e2833ace`](https://github.com/NixOS/nixpkgs/commit/e2833acefc33729fa390610ed75dc0e9a85995c6) | `` Revert "stalwart-mail: use system jemalloc" (#411201) ``                |
| [`3afc9d7b`](https://github.com/NixOS/nixpkgs/commit/3afc9d7bb2c78472c90b87ac9964335de3f64c5f) | `` python313Packages.dissect-esedb: 3.15 -> 3.16 ``                        |
| [`63a699bb`](https://github.com/NixOS/nixpkgs/commit/63a699bb88aaadd2da6b49e61ddd4cd34b8d2e6f) | `` python313Packages.dissect-volume: 3.13 -> 3.15 ``                       |
| [`e7020c95`](https://github.com/NixOS/nixpkgs/commit/e7020c956f46eadd6c81225709ece83110df62e9) | `` python313Packages.dissect-sql: 3.10 -> 3.11 ``                          |
| [`3470ccf9`](https://github.com/NixOS/nixpkgs/commit/3470ccf95969aa8762f75ea60c05d283d09689a2) | `` hawkeye: 6.0.3 -> 6.0.4 ``                                              |
| [`58d2510e`](https://github.com/NixOS/nixpkgs/commit/58d2510e00f1eeda5107ffede1e5699ee7569b39) | `` python313Packages.dissect-esedb: 3.15 -> 3.16 ``                        |
| [`c3c28da4`](https://github.com/NixOS/nixpkgs/commit/c3c28da4cea4dac1a1d138ffc494f26da82d5e0f) | `` python313Packages.dissect-etl: disable failing tests ``                 |
| [`1a08674e`](https://github.com/NixOS/nixpkgs/commit/1a08674e838d36c2ab1826c17e378ad7cbce3b97) | `` python313Packages.dissect-util: 3.19 -> 3.21 ``                         |
| [`ff8c965f`](https://github.com/NixOS/nixpkgs/commit/ff8c965f83280d6b08c6788a351ad6491c3d7db2) | `` mani: 0.30.1 -> 0.31.0 ``                                               |
| [`b134f314`](https://github.com/NixOS/nixpkgs/commit/b134f3148fb2b457f547842f173e34767d4d969f) | `` nixos/postgrest: fix typo in name of configuration options (#411197) `` |
| [`f827baed`](https://github.com/NixOS/nixpkgs/commit/f827baed5476f2963c50796007089d209955e0d6) | `` ngtcp2: 1.12.0 -> 1.13.0 ``                                             |
| [`5c03c653`](https://github.com/NixOS/nixpkgs/commit/5c03c6538b664b1e007deeb8b4ce8043db4b5df2) | `` python313Packages.dissect-cstruct: 4.3 -> 4.5 ``                        |
| [`48a847e7`](https://github.com/NixOS/nixpkgs/commit/48a847e7b1f2df1ab34dd405fd23a38af4a2dbaf) | `` nixpkgs-track: 0.2.0 -> 0.3.0 ``                                        |
| [`4d243ac1`](https://github.com/NixOS/nixpkgs/commit/4d243ac17f6496434c010c393b2b9ecc37581a67) | `` vscode-extensions.shopify.ruby-lsp: 0.9.24 -> 0.9.26 ``                 |
| [`db74113a`](https://github.com/NixOS/nixpkgs/commit/db74113a3ef6c78486ac7abe11f2d3101c2e0176) | `` smenu: 1.4.0 -> 1.5.0 ``                                                |
| [`ee8175da`](https://github.com/NixOS/nixpkgs/commit/ee8175da2a7a7fd00b52e66981f9829bbf36764b) | `` iamb: Install additional files ``                                       |
| [`7bce612d`](https://github.com/NixOS/nixpkgs/commit/7bce612d50f2b721861ce5398273b8aa61238d18) | `` python3Packages.pycrdt: 0.12.18 -> 0.12.20 ``                           |
| [`89c37a00`](https://github.com/NixOS/nixpkgs/commit/89c37a0096ce980cfff77680f3a9526a22baaa9b) | `` craftos-pc: add maintainer ``                                           |
| [`9612a687`](https://github.com/NixOS/nixpkgs/commit/9612a687810f32ec3457f6106f773a150e2a30c9) | `` craftos-pc: add missing dependency ``                                   |
| [`a7e0838d`](https://github.com/NixOS/nixpkgs/commit/a7e0838d75b93f222ab96ce5ea5c074a1b4d2b6c) | `` python3Packages.publicsuffixlist: 1.0.2.20250521 -> 1.0.2.20250523 ``   |
| [`3a7b2ee4`](https://github.com/NixOS/nixpkgs/commit/3a7b2ee4ed05bb06430f1d7d268c53cd18905711) | `` python3Packages.xarray-einstats: 0.8.0 -> 0.9.0 ``                      |
| [`f0b02bea`](https://github.com/NixOS/nixpkgs/commit/f0b02bea3d9a340c1df3a7c80ab79b6ab9f23c48) | `` iperf3: 3.18 -> 3.19 ``                                                 |
| [`e437cdb8`](https://github.com/NixOS/nixpkgs/commit/e437cdb89f5d5fa8424fe359bb5dd936bdcfd4ea) | `` radarr: 5.21.1.9799 -> 5.24.1.10017 ``                                  |
| [`5bc0591c`](https://github.com/NixOS/nixpkgs/commit/5bc0591cec19c440ce3a4c66479ce0b75e4d561b) | `` labelImg: cleanup ``                                                    |
| [`acdc5695`](https://github.com/NixOS/nixpkgs/commit/acdc56953883a3e806e5f6c45b8b1c968a0eb5e9) | `` labelImg: use `src.tag` ``                                              |
| [`9d4bcc0e`](https://github.com/NixOS/nixpkgs/commit/9d4bcc0e9c4ea51b9a670631d3f5ce0eb91991b7) | `` labelImg: update repository URL ``                                      |
| [`c3c09acb`](https://github.com/NixOS/nixpkgs/commit/c3c09acbaa38eb61d236045f914809d0c41745a0) | `` labelImg: add missing `distutils` runtime dependency ``                 |
| [`ce1ce114`](https://github.com/NixOS/nixpkgs/commit/ce1ce114509ce8d4171aa7397bc170e2db83fefc) | `` dgraph: 24.1.2 -> 24.1.3 ``                                             |
| [`e3a17dd0`](https://github.com/NixOS/nixpkgs/commit/e3a17dd022423a7557829803363ba50fb194f44a) | `` darkly: 0.5.19 -> 0.5.20 ``                                             |
| [`45b9af3a`](https://github.com/NixOS/nixpkgs/commit/45b9af3adf4f65f8fc0f406cacfb7ecc3fa3c444) | `` geteduroam: 0.10 -> 0.11 ``                                             |
| [`7dd7cf00`](https://github.com/NixOS/nixpkgs/commit/7dd7cf0040806f27ba171725b287f48d1c12f7a7) | `` htmlhint: 1.1.4 -> 1.2.0 ``                                             |
| [`0092d4d3`](https://github.com/NixOS/nixpkgs/commit/0092d4d3c6130681e0cca4983efab7651f00c38a) | `` python3Packages.aider-chat: 0.83.1 -> 0.83.2 ``                         |
| [`884ab242`](https://github.com/NixOS/nixpkgs/commit/884ab2420b39865a7cd2a45a1ff62883ab5ef72e) | `` nss_latest: 3.111 -> 3.112 ``                                           |
| [`48873942`](https://github.com/NixOS/nixpkgs/commit/488739423ea3b5ef4c05c6aab0d39e524323a5b4) | `` cedar: 4.4.0 -> 4.4.1 ``                                                |
| [`2a199ea7`](https://github.com/NixOS/nixpkgs/commit/2a199ea713f2d8f12b098b023c102ad1c9c7e27c) | `` python3Packages.llama-index: 0.12.36 -> 0.12.37 ``                      |
| [`6e99825c`](https://github.com/NixOS/nixpkgs/commit/6e99825c1830d6a816b26ac7d303d6e0832f4f74) | `` nixos/adguardhome: Update binary path ``                                |
| [`a2686ae9`](https://github.com/NixOS/nixpkgs/commit/a2686ae9702f6677bca09f81d793c68e5c5b3317) | `` adguardhome: Add baksa to maintainers ``                                |
| [`a7160b00`](https://github.com/NixOS/nixpkgs/commit/a7160b00117aac9f3e84d5e2269bcd83964f70af) | `` adguardhome: Build from source ``                                       |
| [`81d29aec`](https://github.com/NixOS/nixpkgs/commit/81d29aecb9b1f56acdbd1eafc80347d5775f7c62) | `` opensmtpd-table-*: fix meta.description ``                              |
| [`d1a95afa`](https://github.com/NixOS/nixpkgs/commit/d1a95afae637bfe6ef457b411c11bea52eebb851) | `` python3Packages.hepunits: 2.3.5 -> 2.3.6 ``                             |
| [`67447091`](https://github.com/NixOS/nixpkgs/commit/67447091217b3585604d56a338933429d2ad8a9a) | `` chatty: 0.8.7 -> 0.8.8 ``                                               |
| [`cb9ad1ba`](https://github.com/NixOS/nixpkgs/commit/cb9ad1ba7a7c513b944ffd971cdc3f9165a301c5) | `` flare-signal: 0.16.0 -> 0.16.1 ``                                       |
| [`091f2c0e`](https://github.com/NixOS/nixpkgs/commit/091f2c0e218efdf5b44820986af556694b8ab726) | `` fsautocomplete: 0.77.7 -> 0.78.1 ``                                     |
| [`2bfd312d`](https://github.com/NixOS/nixpkgs/commit/2bfd312d36e7f17df817aeef7e73d289230d9fc9) | `` python3Packages.svg2tikz: 3.3.0 -> 3.3.1 ``                             |
| [`cd6a75f0`](https://github.com/NixOS/nixpkgs/commit/cd6a75f099be6b015aa17f3e8a733cdef44cd724) | `` nekoray: install icon ``                                                |
| [`6181ed5d`](https://github.com/NixOS/nixpkgs/commit/6181ed5dec602c83f3db78be84974896c850a4ce) | `` kid3: use cmakeBool for WITH_MP4V2 build flag instead of string ``      |
| [`deefe7bc`](https://github.com/NixOS/nixpkgs/commit/deefe7bcd53545cd3c15440316f9ae1d87be0732) | `` z-lua: 1.8.21 -> 1.8.24 ``                                              |
| [`225c8d24`](https://github.com/NixOS/nixpkgs/commit/225c8d24234234190c9b3f8edd11f3c6a0df83bc) | `` python3Packages.python-unshare: remove ``                               |
| [`65f536eb`](https://github.com/NixOS/nixpkgs/commit/65f536eb58d4743e7468185beaa0bb2e32a81ad3) | `` deja-dup: add restic support ``                                         |
| [`506a5143`](https://github.com/NixOS/nixpkgs/commit/506a5143544a4e109f867b72b6fbe39b1eadd926) | `` deja-dup: 47.0 -> 48.2 ``                                               |
| [`b8c8b5c8`](https://github.com/NixOS/nixpkgs/commit/b8c8b5c847fbedfb3825a3b292692c07e903ea78) | `` opendht: 3.2.0 -> 3.4.0 ``                                              |
| [`7a056e97`](https://github.com/NixOS/nixpkgs/commit/7a056e973cf8bc283925cc4d318f9bf15d3f2bae) | `` prometheus-borgmatic-exporter: 0.2.8 -> 0.3.0 ``                        |
| [`e1271808`](https://github.com/NixOS/nixpkgs/commit/e127180823b61f1920da2908e3be5b675cee7309) | `` evcxr: 0.19.0 -> 0.20.0 ``                                              |
| [`055f524a`](https://github.com/NixOS/nixpkgs/commit/055f524a04e4c25d220eecea987eeace570824b9) | `` pixelorama: Pin Godot version ``                                        |
| [`6c8394c3`](https://github.com/NixOS/nixpkgs/commit/6c8394c3dc8c2b672177f2ea58fccfa4101af689) | `` jami: 20241031.0 -> 20250523.0 ``                                       |
| [`302bf6ac`](https://github.com/NixOS/nixpkgs/commit/302bf6acc5e4defbf72c2443f64cc4f6cd31631c) | `` pjsip: 2.14.1 -> 2.15.1 ``                                              |
| [`30f53978`](https://github.com/NixOS/nixpkgs/commit/30f53978cef4effec1e25eb5af0bf47aa71ed385) | `` xastir: 2.2.0 -> 2.2.2 ``                                               |
| [`6d72cf3d`](https://github.com/NixOS/nixpkgs/commit/6d72cf3dcd7075100aeb79a37b6801e5551ba185) | `` sigma-cli: 1.0.5 -> 1.0.6 ``                                            |
| [`81ab30af`](https://github.com/NixOS/nixpkgs/commit/81ab30af5839263139fb10653490bca2b25c6458) | `` sql-formatter: 15.6.1 -> 15.6.2 ``                                      |
| [`b2d685de`](https://github.com/NixOS/nixpkgs/commit/b2d685de4ab8bba24c892713f836c3cf5a925b07) | `` hugo: 0.147.3 -> 0.147.5 ``                                             |
| [`eb4713a8`](https://github.com/NixOS/nixpkgs/commit/eb4713a85c618cea5ee204b6163fdd91fc5f39be) | `` python3Packages.incomfort-client: 0.6.8 -> 0.6.9 ``                     |
| [`b85b8e70`](https://github.com/NixOS/nixpkgs/commit/b85b8e703452261ea8c91eed1f44107aaebf5c35) | `` atmos: 1.174.0 -> 1.176.0 ``                                            |
| [`c61f98de`](https://github.com/NixOS/nixpkgs/commit/c61f98deb5232c39114cd130df4fdba190abc283) | `` tts: 0.26.0 -> 0.26.2 ``                                                |
| [`15a6e88a`](https://github.com/NixOS/nixpkgs/commit/15a6e88a3a106863edb8344cc7ed35a0d61c3ab7) | `` shadps4: use eboot.bin instead ``                                       |
| [`d721272b`](https://github.com/NixOS/nixpkgs/commit/d721272be008fc0aac4d0b02259a3fd8c4da5c45) | `` shadps4: 0.7.0 -> 0.9.0 ``                                              |
| [`2efd5307`](https://github.com/NixOS/nixpkgs/commit/2efd5307e4966e12672737101826947b8a02eb25) | `` ospd-openvas: 22.8.2 -> 22.9.0 ``                                       |
| [`57b89291`](https://github.com/NixOS/nixpkgs/commit/57b892912c4d9ae0083d16cd2a6db790df2d70be) | `` netdata: 2.5.1 -> 2.5.2 ``                                              |
| [`802c7943`](https://github.com/NixOS/nixpkgs/commit/802c794335c5de28f5b750100ba5235be001db02) | `` python3Packages.meep: 1.30.0 -> 1.30.1 ``                               |
| [`a052238a`](https://github.com/NixOS/nixpkgs/commit/a052238a68263552a4a6563395bbcdb81d3c4923) | `` spider: 2.37.18 -> 2.37.79 ``                                           |
| [`86fe0dd7`](https://github.com/NixOS/nixpkgs/commit/86fe0dd79bbc4b0d0998647a4b3df790b94809ad) | `` raycast: 1.99.0 -> 1.99.2 ``                                            |
| [`d6c56af5`](https://github.com/NixOS/nixpkgs/commit/d6c56af5139c93026757cf5c3301eb26b6f2af4c) | `` taterclient-ddnet: 10.1.2 -> 10.3.0 ``                                  |
| [`027db59c`](https://github.com/NixOS/nixpkgs/commit/027db59c22d4bcc66eb2fd8215a333f239a91416) | `` terraform-compliance: 1.3.50 -> 1.3.52 ``                               |
| [`69984d59`](https://github.com/NixOS/nixpkgs/commit/69984d594fc4d175fd0cf0762f98801dc598b99d) | `` tailscale: re-enable `packet_filter_test.go` ``                         |
| [`25122135`](https://github.com/NixOS/nixpkgs/commit/25122135e6c5976ee41c0d560c125a618ee53d6d) | `` tailscale: remove unused fetchpatch ``                                  |
| [`781a8765`](https://github.com/NixOS/nixpkgs/commit/781a87653e8f479cc02a4c5b6a6128c14b1ba61f) | `` infra-arcana: 22.1.0 -> 23.0.0 ``                                       |
| [`a296d255`](https://github.com/NixOS/nixpkgs/commit/a296d255d98fcac8de4353027b84f3b6ba09650e) | `` tailscale: disable packet_filter_test ``                                |
| [`4b78b9be`](https://github.com/NixOS/nixpkgs/commit/4b78b9bee5031af00396643018feb2d2b9045c31) | `` tailscale: disable timeout taildrop tests ``                            |
| [`046d9dbe`](https://github.com/NixOS/nixpkgs/commit/046d9dbefeb11d527490584b6cfcb141fcd33fb9) | `` tailscale: 1.82.5 -> 1.84.0 ``                                          |
| [`d7892a79`](https://github.com/NixOS/nixpkgs/commit/d7892a79af430a887492b0537325c5e93779ba99) | `` sparrow: 2.0.0 -> 2.2.1 ``                                              |
| [`ecb7b2e9`](https://github.com/NixOS/nixpkgs/commit/ecb7b2e94037b2260dc155042fbf2db709c6249b) | `` snobol4: 2.3.2 -> 2.3.3 ``                                              |
| [`34bada88`](https://github.com/NixOS/nixpkgs/commit/34bada88632e7bac55078e55568f559c03f6887d) | `` apr: 1.7.5 -> 1.7.6 ``                                                  |
| [`d0cff692`](https://github.com/NixOS/nixpkgs/commit/d0cff692460f2dec0d71e72b2b7bc78b18cca59a) | `` grandorgue: Use wrapGAppsHook3 to provide correct environment ``        |
| [`a29c95ae`](https://github.com/NixOS/nixpkgs/commit/a29c95ae6def820e32b5844b13c4914326106352) | `` python313Packages.granian: 2.3.0 -> 2.3.1 ``                            |
| [`7ccae6c5`](https://github.com/NixOS/nixpkgs/commit/7ccae6c5a033280879433906f45d26d1087b8a68) | `` qgis-ltr: 3.40.6 -> 3.40.7 ``                                           |
| [`3b7b7eec`](https://github.com/NixOS/nixpkgs/commit/3b7b7eec1ecfa646a4313b6e61cebbbd79f7fd96) | `` qgis: 3.42.2 -> 3.42.3 ``                                               |
| [`748d64c2`](https://github.com/NixOS/nixpkgs/commit/748d64c23c97816964cedbfa348c55a6a79bac3e) | `` opencsg: 1.7.0 -> 1.8.1 ``                                              |
| [`a10c6a20`](https://github.com/NixOS/nixpkgs/commit/a10c6a2007e2215a6c97db6efad110c12b055b7b) | `` python313Packages.granian: 2.2.5 -> 2.3.0 ``                            |
| [`bc8ee2f8`](https://github.com/NixOS/nixpkgs/commit/bc8ee2f85190d32f939c8a6c028d70b9dc326ab7) | `` llvmPackages_20: 20.1.4 -> 20.1.5 ``                                    |
| [`9d1654b9`](https://github.com/NixOS/nixpkgs/commit/9d1654b9816a582b84a4965b962b8091d5c69106) | `` edmarketconnector: init at 5.13.1 ``                                    |
| [`7e42e443`](https://github.com/NixOS/nixpkgs/commit/7e42e4431b0692c4968c4114d977aa311969a774) | `` virtualisation/docker: fix nvidia container wrapper ``                  |
| [`49545155`](https://github.com/NixOS/nixpkgs/commit/495451554fc9e53e47dc86ece5f6e5c4736566b2) | `` deja-dup: 47.0 -> 48.1 ``                                               |
| [`7491fdf6`](https://github.com/NixOS/nixpkgs/commit/7491fdf61f3b294f396f6cfccac1d12ce5b600ed) | `` kid3: enable build flag WITH_MP4V2 ``                                   |
| [`36459b8f`](https://github.com/NixOS/nixpkgs/commit/36459b8fe14e44b9f49047198864f860c0177207) | `` fishPlugins.macos: add updateScript ``                                  |
| [`cb844fda`](https://github.com/NixOS/nixpkgs/commit/cb844fda2ed473c1ae2ebd6668a3263a4ced3675) | `` fishPlugins.macos: 7.0.0 -> 7.0.1 ``                                    |