### PR TITLE
Update Zed Editor packages

### DIFF
--- a/packages/zed-editor-bin/default.nix
+++ b/packages/zed-editor-bin/default.nix
@@ -18,7 +18,7 @@
   testers,
   lib,
 }: let
-  version = "0.187.9";
+  version = "0.188.3";
 
   # Map from Nix system → { url, sha256, type }
   assets = {
@@ -26,28 +26,28 @@
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-x86_64.tar.gz";
-      sha256 = "sha256-oGbulX86pj040FTsq9LI2I3iSCX6hgG4SyKVU0U89p8=";
+      sha256 = "sha256-rKWZigNqDznUHi0oyJdBMaqeNC+l+emURp3LUuxFg6g=";
       type = "tar.gz";
     };
     "aarch64-linux" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-aarch64.tar.gz";
-      sha256 = "sha256-T7xbIS0L8kVx25M/beZBY/BLDcFiDiXn0LEOEhaP0a8=";
+      sha256 = "sha256-TiZErwlxl7XpDSwX3j0tDXeswHqtobF0jBzBNDh470k=";
       type = "tar.gz";
     };
     "x86_64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-x86_64.dmg";
-      sha256 = "sha256-PfRcswkYrmJwpljzQDiiBbZ5KIW26gT7GJuTZPPR5po=";
+      sha256 = "sha256-ealaUhVBbDBzyVVAm+uecC73Oqo8MJ74eanq3NsgNSc=";
       type = "dmg";
     };
     "aarch64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-aarch64.dmg";
-      sha256 = "sha256-y+vUMYlOpuPPYZxvegyatlYVhaJtjsj8nlB/CXLBJpg=";
+      sha256 = "sha256-75c7iSSWv9f+jKvM7kB0OtTG1RPFz1fKwLUQwlyBCIU=";
       type = "dmg";
     };
   };

--- a/packages/zed-editor/default.nix
+++ b/packages/zed-editor/default.nix
@@ -98,7 +98,7 @@ assert withGLES -> stdenv.hostPlatform.isLinux; let
 in
   rustPlatform.buildRustPackage (finalAttrs: {
     pname = "zed-editor";
-    version = "0.187.9";
+    version = "0.188.3";
 
     outputs =
       ["out"]
@@ -110,7 +110,7 @@ in
       owner = "zed-industries";
       repo = "zed";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-BWn36z6EoyYRGtYZjWmTbu77M2wYNNBQ76u6MhKlkY4=";
+      hash = "sha256-ZyKFzb6/kVw/uLTmhnyrwmgyTHTwgu/WbOga409eZvg=";
     };
 
     patches = [
@@ -129,7 +129,7 @@ in
       '';
 
     useFetchCargoVendor = true;
-    cargoHash = "sha256-0EM3RaY9gClWsDGPrNo8JN80Wv5rKU84IyWkT4HZnJY=";
+    cargoHash = "sha256-fwX9wEbSDPqXz9j794K+S4mO/RYKuC+i7XVUwoAGL54=";
 
     nativeBuildInputs =
       [


### PR DESCRIPTION
This PR updates Zed Editor packages.

**Stable Channel:**
Updated from `0.187.9` to `0.188.3`.

Changes:
- Updated package versions in both `zed-editor` and `zed-editor-bin`
- Updated source hash in `zed-editor`
- Updated cargo hash in `zed-editor`
- Updated binary hashes in `zed-editor-bin`

Automatic Hash Updates (Stable):
Source hash for zed-editor: `sha256-ZyKFzb6/kVw/uLTmhnyrwmgyTHTwgu/WbOga409eZvg=`
Cargo hash for zed-editor: `sha256-fwX9wEbSDPqXz9j794K+S4mO/RYKuC+i7XVUwoAGL54=`
Binary hashes for zed-editor-bin:
- x86_64-linux: `sha256-rKWZigNqDznUHi0oyJdBMaqeNC+l+emURp3LUuxFg6g=`
- aarch64-linux: `sha256-TiZErwlxl7XpDSwX3j0tDXeswHqtobF0jBzBNDh470k=`
- x86_64-darwin: `sha256-ealaUhVBbDBzyVVAm+uecC73Oqo8MJ74eanq3NsgNSc=`
- aarch64-darwin: `sha256-75c7iSSWv9f+jKvM7kB0OtTG1RPFz1fKwLUQwlyBCIU=`

**Flake:**
- Updated `flake.lock`

This update was created automatically by GitHub Actions.