### PR TITLE
Updating zed packages and using rust overlay to solve anonymous_pipe unstable error.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,7 +69,28 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "patched-nixpkgs": "patched-nixpkgs"
+        "patched-nixpkgs": "patched-nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749868581,
+        "narHash": "sha256-oWO5KAIjhclLwYJp7kJiNbNqCcZo8ZLuKQEJd9WL6r4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2ff6d56a67d75559f7b5d9edf9aa1fcf8e15f461",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,13 @@
                 };
               };
               zed-editor-fhs = self'.packages.zed-editor.passthru.fhs;
-              zed-editor-preview = pkgs.callPackage ./packages/zed-editor-preview { };
+              zed-editor-preview = pkgs.callPackage ./packages/zed-editor-preview { 
+                # Use latest stable rust
+                rustPlatform = pkgs.makeRustPlatform {
+                  cargo = pkgs.rust-bin.stable.latest.default;
+                  rustc = pkgs.rust-bin.stable.latest.default;
+                };
+              };
               zed-editor-preview-fhs = self'.packages.zed-editor-preview.passthru.fhs;
               zed-editor-bin = pkgs.callPackage ./packages/zed-editor-bin { };
               zed-editor-bin-fhs = self'.packages.zed-editor-bin.passthru.fhs;

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,19 @@
 {
   description = "A flake providing an up-to-date package for zed-editor";
-
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     patched-nixpkgs.url = "github:TomaSajt/nixpkgs?ref=fetch-cargo-vendor-dup";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
-
   outputs =
     inputs @ { flake-parts
     , nixpkgs
     , patched-nixpkgs
+    , rust-overlay
     , ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } (
@@ -20,7 +23,6 @@
       , ...
       }: {
         systems = with nixpkgs.lib.platforms; linux ++ darwin;
-
         perSystem =
           { system
           , pkgs
@@ -28,26 +30,31 @@
           , inputs'
           , ...
           }:
-          # let
-          #   rustPlatform = inputs'.patched-nixpkgs.legacyPackages.rustPlatform;
-          # in
+          let
+            # Apply rust overlay to get latest rust
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ rust-overlay.overlays.default ];
+            };
+          in
           {
             packages = {
-              zed-editor = pkgs.callPackage ./packages/zed-editor { };
+              zed-editor = pkgs.callPackage ./packages/zed-editor { 
+                # Use latest stable rust
+                rustPlatform = pkgs.makeRustPlatform {
+                  cargo = pkgs.rust-bin.stable.latest.default;
+                  rustc = pkgs.rust-bin.stable.latest.default;
+                };
+              };
               zed-editor-fhs = self'.packages.zed-editor.passthru.fhs;
-
               zed-editor-preview = pkgs.callPackage ./packages/zed-editor-preview { };
               zed-editor-preview-fhs = self'.packages.zed-editor-preview.passthru.fhs;
-
               zed-editor-bin = pkgs.callPackage ./packages/zed-editor-bin { };
               zed-editor-bin-fhs = self'.packages.zed-editor-bin.passthru.fhs;
-
               zed-editor-preview-bin = pkgs.callPackage ./packages/zed-editor-preview-bin { };
               zed-editor-preview-bin-fhs = self'.packages.zed-editor-preview-bin.passthru.fhs;
-
               default = self'.packages.zed-editor;
             };
-
             apps = {
               zed-editor.program = "${self'.packages.zed-editor}/bin/zeditor";
               zed-editor-fhs.program = "${self'.packages.zed-editor-fhs}/bin/zeditor";

--- a/packages/zed-editor-bin/default.nix
+++ b/packages/zed-editor-bin/default.nix
@@ -18,7 +18,7 @@
   testers,
   lib,
 }: let
-  version = "0.189.5";
+  version = "0.190.6";
 
   # Map from Nix system → { url, sha256, type }
   assets = {
@@ -26,28 +26,28 @@
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-x86_64.tar.gz";
-      sha256 = "sha256-aXZTHRUJ3kAokbYhEqEuCzjpFV0A7Zjasgp7qnm0H8s=";
+        sha256 = "sha256-2cZOGgFk/GVJksidk1MsiS0tyvelhB9ZUCVKzabFACc=";
       type = "tar.gz";
     };
     "aarch64-linux" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-aarch64.tar.gz";
-      sha256 = "sha256-8dxTwDCOe5RINM0zb3Q1UD1+DSE080F0iFadlOIgzSE=";
+      sha256 = "sha256-/0Uki41cPY7N+nLsZaQR7DpTtezwOcfbDANNH8jQY9k=";
       type = "tar.gz";
     };
     "x86_64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-x86_64.dmg";
-      sha256 = "sha256-B6UA/ua44/UGk/Y6SjebO1w/J9ZR0y4c+WpslQMYVko=";
+      sha256 = "sha256-CsiGTMpbp9jdgmD4nDfin0Qijaf6eGcXymh3nX9JzqI=";
       type = "dmg";
     };
     "aarch64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-aarch64.dmg";
-      sha256 = "sha256-jqWcVzE5KqxCXljXrljdvsPMzljWyvyxbdzi07+QhVA=";
+      sha256 = "sha256-hvPV8QRfevItzLgLYbYXiYp/8ztr2JYed0CHgx3mntM=";
       type = "dmg";
     };
   };

--- a/packages/zed-editor-preview-bin/default.nix
+++ b/packages/zed-editor-preview-bin/default.nix
@@ -18,7 +18,7 @@
   testers,
   lib,
 }: let
-  version = "0.190.3-pre";
+  version = "0.191.2-pre";
 
   # Map from Nix system → { url, sha256, type }
   assets = {
@@ -26,28 +26,28 @@
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-x86_64.tar.gz";
-      sha256 = "sha256-V81S4q7DIbrGDF2sV1ek25OqMsgxLZEMiFZi9hqzahU=";
+        sha256 = "sha256-n4EMMphANf3+d7K6LSyWq+vDtTIrQ8+83dgGs3VTTkg=";
       type = "tar.gz";
     };
     "aarch64-linux" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/zed-linux-aarch64.tar.gz";
-      sha256 = "sha256-gwQ6ipSc3OMF4Ze3JI81VKYsf0ADAyz9gWbofjJ7DSQ=";
+      sha256 = "sha256-X0kfIQEdxN70a5c7XWQcVX9i5NjdULqFUIjAVXQqMgo=";
       type = "tar.gz";
     };
     "x86_64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-x86_64.dmg";
-      sha256 = "sha256-wlpeFtHsuB6I2tnklya4PcyWUoEHBaqWJQYbZpGHGsI=";
+      sha256 = "sha256-kuaK0G5kJrSH/6CJWp9CmQeTARQHi66MB9nqQ0m7nkA=";
       type = "dmg";
     };
     "aarch64-darwin" = {
       url =
         "https://github.com/zed-industries/zed/releases/download/"
         + "v${version}/Zed-aarch64.dmg";
-      sha256 = "sha256-w4uPVYumE2fIqSyQ9WbBTj81Yd3luWRjSUVbzTHrJVg=";
+      sha256 = "sha256-vhxV/yPj+h+hXO2CUWy6c40Dgz64Cm2qTAUQmI9YwP8=";
       type = "dmg";
     };
   };

--- a/packages/zed-editor-preview/default.nix
+++ b/packages/zed-editor-preview/default.nix
@@ -98,7 +98,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zed-editor";
-  version = "0.190.3-pre";
+  version = "0.191.2-pre";
 
   outputs =
     [ "out" ]
@@ -110,7 +110,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "zed-industries";
     repo = "zed";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZJ7zLlPuM+AInVYFlYyH8PpDDUFgftL0SBWJY4Ws46Y=";
+    hash = "sha256-gMDa/Qt5k7YP+dp5GtCNCww5TxuM+QAIreMmB0/YLMY=";
   };
 
   patches = [
@@ -137,7 +137,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-uNm7JLHvoC/e3vrMrm57iuepdmM9JpPVOGE/ev/vdyU=";
+  cargoHash = "sha256-3JhvEUkdQioU4SlesMKg1hAJ7HkDC91f6yqfTvzLz4k=";
 
   nativeBuildInputs =
     [

--- a/packages/zed-editor/default.nix
+++ b/packages/zed-editor/default.nix
@@ -98,7 +98,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zed-editor";
-  version = "0.189.5";
+  version = "0.190.6";
 
   outputs =
     [ "out" ]
@@ -110,7 +110,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "zed-industries";
     repo = "zed";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-d1d3WgUVamrYWVosljQiEPZGNNDldtM1YwZhxseX4+w=";
+    hash = "sha256-wtzTdYUgP/YOHE21HFH/+DYjBRviVxjr+Rb5SQ0cWvc=";
   };
 
   patches = [
@@ -137,7 +137,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-YhdwCNTbBphWugguoWQqrGf2fRB5Jv40MElW6hbcxtk=";
+  cargoHash = "sha256-wTdsXNw9wPikpRIRMR19x8DrHJD4mxIKdAz/L/HMCII=";
 
   nativeBuildInputs =
     [


### PR DESCRIPTION
To solve this 
```
error: Cannot build '/nix/store/01xkiq2nhl47k5rdqdygz9zv21n1h80j-zed-editor-0.190.6.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/9kmls4bdkf9m56i04c6x55gd519k08g9-zed-editor-0.190.6
         /nix/store/ssahfy6b83faqb9w0n70vq8w6czpqssa-zed-editor-0.190.6-remote_server
       Last 25 log lines:
       >    Compiling dirs v4.0.0
       >    Compiling collections v0.1.0 (/build/source/crates/collections)
       >    Compiling dlib v0.5.2
       >    Compiling itertools v0.14.0
       >    Compiling unicase v2.8.1
       >    Compiling command-fds v0.3.1
       >    Compiling async_zip v0.0.17
       >    Compiling strum_macros v0.27.1
       >    Compiling wayland-sys v0.31.6
       >    Compiling slotmap v1.0.7
       >    Compiling take-until v0.2.0
       >    Compiling util v0.1.0 (/build/source/crates/util)
       >    Compiling wayland-backend v0.3.8
       > error[E0658]: use of unstable library feature `anonymous_pipe`
       >   --> crates/util/src/shell_env.rs:79:32
       >    |
       > 79 |     let (mut reader, writer) = std::io::pipe()?;
       >    |                                ^^^^^^^^^^^^^
       >    |
       >    = note: see issue #127154 <https://github.com/rust-lang/rust/issues/127154> for more information
       >
       >    Compiling downcast-rs v1.2.1
       > For more information about this error, try `rustc --explain E0658`.
       > error: could not compile `util` (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
         nix log /nix/store/01xkiq2nhl47k5rdqdygz9zv21n1h80j-zed-editor-0.190.6.drv
```

## Summary by Sourcery

Use rust-overlay in the Nix flake to supply an updated Rust toolchain and fix a build failure, and bump Zed package versions with updated checksums.

Bug Fixes:
- Fix build error caused by Rust’s unstable `anonymous_pipe` feature by switching to a newer toolchain from rust-overlay.

Enhancements:
- Add `rust-overlay` input to the flake and apply it when importing Nixpkgs.
- Configure the `zed-editor` derivation to use `makeRustPlatform` with the latest stable Rust binaries from rust-overlay.

Build:
- Update flake.nix to include and apply rust-overlay in package imports.

Chores:
- Bump versions of `zed-editor`, `zed-editor-preview`, and their CLI binaries.
- Update sha256 checksums for all bumped Zed package assets.